### PR TITLE
docs: Add workspace reference for agentic coding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,102 @@
+⚠️ **THESE RULES ONLY APPLY TO FILES IN /halos-marine-containers/** ⚠️
+
+# HaLOS Marine Containers - Development Guide
+
+## 🎯 For Agentic Coding: Use the HaLOS Workspace
+
+This repository should be used as part of the halos-distro workspace for AI-assisted development:
+
+```bash
+# Clone workspace and all repos
+git clone https://github.com/hatlabs/halos-distro.git
+cd halos-distro
+./run repos:clone
+```
+
+See `halos-distro/docs/` for development workflows and guidance.
+
+## About This Project
+
+Marine container store definition and curated marine application definitions.
+
+**Local Instructions**: For environment-specific instructions and configurations, see @CLAUDE.local.md (not committed to version control).
+
+## Git Workflow Policy
+
+**Branch Workflow:** Never push to main directly - always use feature branches and PRs.
+
+**Link issues and PRs:** Always link related GitHub issues in PR descriptions with `Closes #<issue-number>`.
+
+## What This Repository Contains
+
+**Two things in one repository**:
+1. **Marine Container Store** (`store/`) - Store definition package
+2. **Marine Apps** (`apps/`) - Curated marine application definitions
+
+**Rationale**: Store and apps are tightly coupled. The store defines which apps belong in the marine category, and those apps live right here. Single source of truth, unified CI/CD.
+
+## Repository Structure
+
+```
+halos-marine-containers/
+├── store/
+│   ├── marine.yaml          # Store configuration
+│   ├── icon.svg             # Branding (256x256)
+│   ├── banner.png           # Branding (1200x300)
+│   └── debian/              # Debian packaging for store package
+│       ├── control
+│       ├── rules
+│       ├── install
+│       └── ...
+├── apps/
+│   ├── signalk-server/
+│   │   ├── docker-compose.yml
+│   │   ├── config.yml
+│   │   ├── metadata.json
+│   │   └── icon.png
+│   ├── opencpn/
+│   └── ...
+├── tools/
+│   └── build-all.sh         # Build all packages
+├── .github/workflows/
+│   └── build.yml            # CI/CD
+├── docs/
+│   └── DESIGN.md            # Detailed design docs
+└── README.md
+```
+
+## Adding a New Marine App
+
+See [docs/DESIGN.md](docs/DESIGN.md) for complete instructions.
+
+**Quick overview**:
+1. Create `apps/<app-name>/` directory
+2. Add `docker-compose.yml`, `config.yml`, `metadata.json`, `icon.png`
+3. Test locally with `generate-container-packages`
+4. Create PR - CI will build and validate
+
+## Building
+
+**Requirements**: `container-packaging-tools` installed
+
+```bash
+# Build all packages (store + apps)
+./tools/build-all.sh
+
+# Output: build/*.deb
+```
+
+**CI/CD**: GitHub Actions builds on push and creates releases.
+
+## Store Configuration
+
+The `store/marine.yaml` defines:
+- Which packages appear in the Marine store (filter rules)
+- Custom section labels and icons
+- Store branding
+
+## Related
+
+- **Parent**: [../AGENTS.md](../AGENTS.md) - Workspace documentation
+- **Tooling**: [container-packaging-tools](https://github.com/hatlabs/container-packaging-tools)
+- **UI**: [cockpit-apt](https://github.com/hatlabs/cockpit-apt)

--- a/README.md
+++ b/README.md
@@ -27,6 +27,27 @@ CI/CD builds multiple Debian packages from this repository:
 
 All packages are published to apt.hatlabs.fi.
 
+## Agentic Coding Setup (Claude Code, GitHub Copilot, etc.)
+
+For development with AI assistants, use the halos-distro workspace for full context:
+
+```bash
+# Clone the workspace
+git clone https://github.com/hatlabs/halos-distro.git
+cd halos-distro
+
+# Get all sub-repositories including halos-marine-containers
+./run repos:clone
+
+# Work from workspace root for AI-assisted development
+# Claude Code gets full context across all repos
+```
+
+See `halos-distro/docs/` for development workflows:
+- `HUMAN_DEVELOPMENT_GUIDANCE.md` - Quick start guide
+- `IMPLEMENTATION_CHECKLIST.md` - Development checklist
+- `DEVELOPMENT_WORKFLOW.md` - Detailed workflows
+
 ## Repository Structure
 
 ```


### PR DESCRIPTION
## Summary

Updates AGENTS.md and README.md to direct AI-assisted development to use the halos-distro workspace for full context across all repositories.

## Changes

- **AGENTS.md**: Added "For Agentic Coding" section with workspace setup instructions
- **README.md**: Added "Agentic Coding Setup" section after build output description

## Rationale

This follows the pattern established in cockpit-apt PR #51. By working from the halos-distro workspace, Claude Code and other AI assistants get access to:
- Complete workspace context across all repos
- Centralized development workflow documentation
- Implementation checklists and best practices

## References

- halos-distro/docs/HUMAN_DEVELOPMENT_GUIDANCE.md
- halos-distro/docs/IMPLEMENTATION_CHECKLIST.md
- halos-distro/docs/DEVELOPMENT_WORKFLOW.md
- cockpit-apt#51 (template for this change)