### PR TITLE
fix(metadata): Change debian_section from navigation to graphics

### DIFF
--- a/apps/avnav/metadata.yaml
+++ b/apps/avnav/metadata.yaml
@@ -29,7 +29,7 @@ tags:
   - interface::web
   - use::routing
   - works-with::maps
-debian_section: navigation
+debian_section: graphics
 architecture: all
 depends:
   - docker-ce (>= 20.10) | docker.io (>= 20.10)

--- a/apps/opencpn/metadata.yaml
+++ b/apps/opencpn/metadata.yaml
@@ -28,7 +28,7 @@ tags:
   - interface::web
   - use::routing
   - works-with::maps
-debian_section: navigation
+debian_section: graphics
 architecture: all
 depends:
   - docker-ce (>= 20.10) | docker.io (>= 20.10)


### PR DESCRIPTION
## Summary

Fixes invalid debian_section in avnav and opencpn packages by changing from 'navigation' (invalid) to 'graphics' (valid official section).

## Problem

- avnav and opencpn used `debian_section: navigation`
- "navigation" is **not** an official Debian section per Policy Manual 4.7.2.0
- Package validation fails with invalid section name

## Solution

Changed both packages to use `debian_section: graphics`:
- ✅ Chart plotting applications display maps/charts (graphical)
- ✅ `graphics` is an official Debian section
- ✅ Most appropriate category for these applications

## Changes

- `apps/avnav/metadata.yaml`: `debian_section: navigation` → `graphics`
- `apps/opencpn/metadata.yaml`: `debian_section: navigation` → `graphics`

## Why Graphics?

Chart plotters are fundamentally **graphical applications** that display cartographic data. The `graphics` section is the most appropriate official Debian section for:
- Map/chart display applications
- Geographic visualization tools
- Navigation chart plotters

Alternatives considered:
- ❌ `misc` - Too generic
- ❌ `science` - Not quite right (these are practical navigation tools, not scientific)
- ✅ `graphics` - Best fit for visual map/chart applications

## Dependencies

- Depends on container-packaging-tools#44 (schema update merged/pending)

## Testing

Packages will build successfully once the schema update is merged.

## Closes

- Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)