### PR TITLE
feat(ci): add release workflow with APT repository integration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Release Published
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  trigger-packaging:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Extract version from tag
+      id: version
+      run: |
+        # Extract version from tag (remove 'v' prefix if present)
+        VERSION="${{ github.event.release.tag_name }}"
+        VERSION="${VERSION#v}"
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        echo "Extracted version: $VERSION"
+
+    - name: Trigger APT repository
+      uses: peter-evans/repository-dispatch@v3
+      with:
+        token: ${{ secrets.REPO_DISPATCH_PAT }}
+        repository: hatlabs/apt.hatlabs.fi
+        event-type: package-updated
+        client-payload: |
+          {
+            "repository": "${{ github.repository }}",
+            "distro": "any",
+            "channel": "stable",
+            "component": "main",
+            "version": "${{ steps.version.outputs.version }}",
+            "release_url": "${{ github.event.release.html_url }}"
+          }


### PR DESCRIPTION
## Summary

Adds a release workflow that automatically triggers APT repository updates when new releases are published. Implements the new apt.hatlabs.fi dispatch protocol from the start.

## Changes

**Added:** `.github/workflows/release.yml`

Workflow behavior:
- Triggers on release published events
- Extracts version from release tag
- Sends `package-updated` dispatch event to apt.hatlabs.fi
- Uses new protocol with: repository, distro, channel, component fields

## Benefits

- ✅ Releases automatically added to APT repository
- ✅ Uses correct new dispatch protocol (no silent failures)
- ✅ Supports multi-distribution targeting
- ✅ Follows same pattern as fixed container-packaging-tools

## Related Issues

- Fixes #3 (Update workflow templates to use new APT repository dispatch protocol)
- Related to #42 (container-packaging-tools APT dispatch fix)

## Testing

Ready for testing once first release is published.

Closes #3