### PR TITLE
fix(ci): use underscore in git tags per DEP-14

### DIFF
--- a/.github/scripts/calculate-revision.sh
+++ b/.github/scripts/calculate-revision.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # Usage: calculate-revision.sh <upstream-version>
 # Example: calculate-revision.sh 0.2.0
 #
-# Finds all git tags matching v<upstream-version>+<N> or v<upstream-version>+<N>~pre
+# Finds all git tags matching v<upstream-version>+<N> or v<upstream-version>+<N>_pre
 # Returns the next N value (highest N + 1)
 # Returns 1 if no matching tags exist
 
@@ -20,8 +20,8 @@ fi
 # Remove 'v' prefix if present
 UPSTREAM_VERSION="${UPSTREAM_VERSION#v}"
 
-# Find all tags matching the pattern: v{version}+{N} or v{version}+{N}~pre
-# Pattern: v0.2.0+1, v0.2.0+1~pre, v0.2.0+2, etc.
+# Find all tags matching the pattern: v{version}+{N} or v{version}+{N}_pre
+# Pattern: v0.2.0+1, v0.2.0+1_pre, v0.2.0+2, etc.
 PATTERN="v${UPSTREAM_VERSION}+*"
 
 # Get all matching tags
@@ -34,12 +34,12 @@ if [ -z "$MATCHING_TAGS" ]; then
 fi
 
 # Extract revision numbers from tags
-# Example: v0.2.0+2~pre -> 2, v0.2.0+3 -> 3
+# Example: v0.2.0+2_pre -> 2, v0.2.0+3 -> 3
 MAX_REVISION=0
 while IFS= read -r tag; do
-    # Extract the number between '+' and either end of string or '~'
-    # Pattern: v0.2.0+N or v0.2.0+N~pre
-    if [[ $tag =~ \+([0-9]+)(~.*)?$ ]]; then
+    # Extract the number between '+' and either end of string or '_'
+    # Pattern: v0.2.0+N or v0.2.0+N_pre
+    if [[ $tag =~ \+([0-9]+)(_.*)?$ ]]; then
         REVISION="${BASH_REMATCH[1]}"
         if [ "$REVISION" -gt "$MAX_REVISION" ]; then
             MAX_REVISION="$REVISION"

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           REVISION="${{ steps.version.outputs.revision }}"
-          PRE_TAG="v${VERSION}+${REVISION}~pre"
+          PRE_TAG="v${VERSION}+${REVISION}_pre"
 
           echo "Creating pre-release: $PRE_TAG"
 
@@ -50,7 +50,7 @@ jobs:
 
           # Create pre-release (automatic, pre-release flag set)
           gh release create "$PRE_TAG" \
-            --title "v${VERSION}+${REVISION}~pre (Pre-release)" \
+            --title "v${VERSION}+${REVISION}_pre (Pre-release)" \
             --notes "Automatic pre-release for repository version ${VERSION}, revision ${REVISION}
 
           This is a development build automatically published to the unstable APT channel.

--- a/tests/test_version_management.py
+++ b/tests/test_version_management.py
@@ -279,9 +279,9 @@ class TestGitHubWorkflows:
         assert "calculate-revision.sh" in content, \
             "auto-release.yml should use calculate-revision.sh"
 
-        # Should use revision-based tag format with tilde for pre-release
-        assert "+${REVISION}~pre" in content or '+${REVISION}~pre' in content, \
-            "auto-release.yml should use +revision~pre tag format"
+        # Should use revision-based tag format with underscore for pre-release
+        assert "+${REVISION}_pre" in content or '+${REVISION}_pre' in content, \
+            "auto-release.yml should use +revision_pre tag format"
 
         # Should use revision-based tag format for stable
         assert "+${REVISION}" in content or '+${REVISION}' in content, \


### PR DESCRIPTION
## Summary

Fixes a critical bug in the versioning scheme: git tags cannot contain tilde (`~`) characters.

Same fix as cockpit-apt#99.

## Problem

Git tag names with tilde are **invalid**:
- ❌ `v0.1.0+1~pre` (invalid - git rejects tilde)
- ✅ `v0.1.0+1_pre` (valid - DEP-14 compliant)

Without this fix, the auto-release workflow would fail when trying to create tags.

## Solution

Replace tilde with underscore in pre-release tags, following [DEP-14](https://dep-team.pages.debian.net/deps/dep14/) version mangling standard:

**Tag format changes:**
- Pre-release: `v0.1.0+1_pre` (was `v0.1.0+1~pre`)
- Stable: `v0.1.0+1` (unchanged)

## Changes

1. **`.github/scripts/calculate-revision.sh`**: Update regex to match `_pre` suffix instead of `~pre`
2. **`.github/workflows/auto-release.yml`**: Use `_pre` instead of `~pre` in tag construction
3. **`tests/test_version_management.py`**: Update tests to expect underscore format

## DEP-14 Compliance

Per DEP-14, underscore in git tags represents tilde in Debian versions:
- Git tag: `v0.1.0+1_pre`
- Debian equivalent (if needed): `0.1.0-1~pre`

Since our package versions come independently from:
- Store: `store/debian/changelog`
- Apps: `apps/*/metadata.yaml`

The git tag is just repository metadata and doesn't need conversion.

## Test Results

All 27 tests passing ✅

```
========================= 27 passed in 0.07s =========================
```

## References

- [DEP-14: Recommended layout for Git packaging repositories](https://dep-team.pages.debian.net/deps/dep14/)
- [git-check-ref-format documentation](https://git-scm.com/docs/git-check-ref-format)
- cockpit-apt#99 (same fix)

Closes #16