### PR TITLE
fix(ci): correctly download container-packaging-tools from releases

### DIFF
--- a/.github/actions/build-deb/action.yml
+++ b/.github/actions/build-deb/action.yml
@@ -11,8 +11,17 @@ runs:
       shell: bash
       run: |
         # Download and install container-packaging-tools from GitHub releases
-        LATEST_RELEASE=$(curl -s https://api.github.com/repos/hatlabs/container-packaging-tools/releases/latest | grep '"tag_name"' | sed -E 's/.*"v([^"]+)".*/\1/')
-        curl -L -o container-packaging-tools.deb "https://github.com/hatlabs/container-packaging-tools/releases/latest/download/container-packaging-tools_${LATEST_RELEASE}_all.deb"
+        # Get the actual .deb asset URL from the latest release
+        ASSET_URL=$(curl -s https://api.github.com/repos/hatlabs/container-packaging-tools/releases/latest | \
+          jq -r '.assets[] | select(.name | endswith(".deb")) | .browser_download_url')
+
+        if [ -z "$ASSET_URL" ]; then
+          echo "Error: Could not find .deb asset in latest release"
+          exit 1
+        fi
+
+        echo "Downloading: $ASSET_URL"
+        curl -L -o container-packaging-tools.deb "$ASSET_URL"
         sudo dpkg -i container-packaging-tools.deb || sudo apt-get install -f -y
         rm container-packaging-tools.deb
 


### PR DESCRIPTION
## Problem

The build action failed when trying to download container-packaging-tools from GitHub releases:

```
curl -L -o container-packaging-tools.deb "https://github.com/hatlabs/container-packaging-tools/releases/latest/download/container-packaging-tools_${LATEST_RELEASE}_all.deb"
# Only downloaded 9 bytes - file not found
dpkg-deb: error: unexpected end of file in archive magic version number
```

**Root cause**: Filename construction was incorrect:
- Expected: `container-packaging-tools_0.2.0+2_all.deb`
- Actual: `container-packaging-tools_0.2.0-2_all+trixie+main.deb`

Differences:
1. Version uses `-` not `+` for revision separator (tag: `v0.2.0+2`, package: `0.2.0-2`)
2. Package has distro+component suffix (`+trixie+main`)

## Solution

Instead of manually constructing the filename, use the GitHub API to:
1. Query the latest release
2. Find the `.deb` asset using `jq`
3. Download using the actual `browser_download_url`

This is more robust and handles any filename format changes automatically.

## Testing

- [ ] CI build succeeds
- [ ] `container-packaging-tools` is correctly installed
- [ ] Marine packages build successfully

## Impact

Critical fix - unblocks all CI/CD builds that depend on `container-packaging-tools`.

Fixes https://github.com/hatlabs/halos-marine-containers/actions/runs/19550003826/job/55978771322