### PR TITLE
fix(ci): run Docker build with correct user permissions

### DIFF
--- a/.github/actions/build-deb/action.yml
+++ b/.github/actions/build-deb/action.yml
@@ -21,6 +21,7 @@ runs:
       shell: bash
       run: |
         docker run --rm \
+          -u $(id -u):$(id -g) \
           -v "$PWD:/workspace" \
           -w /workspace \
           marine-builder \


### PR DESCRIPTION
## Problem

After merging #24, the CI is now failing at the package renaming step with:
```
mv: cannot move 'build/avnav-container_20240520-1_all.deb' to 'build/avnav-container_20240520-1_all+trixie+main.deb': Permission denied
```

## Root Cause

Docker runs as root by default, creating build artifacts owned by `root:root`. The GitHub Actions runner (running as a different user) cannot modify these files, causing permission denied errors when trying to rename them.

## Solution

Run the Docker container with the same UID/GID as the GitHub Actions runner using the `-u` flag:
```bash
docker run --rm \
  -u $(id -u):$(id -g) \
  -v "$PWD:/workspace" \
  -w /workspace \
  marine-builder \
  ./tools/build-all.sh
```

This ensures all build artifacts are created with the correct ownership from the start, avoiding any permission issues.

## Testing

- ✅ Clean solution - no sudo required
- ✅ Files created with correct ownership from the start
- ✅ Should fix the renaming step failure

Fixes: https://github.com/hatlabs/halos-marine-containers/actions/runs/19551127570/job/55982652439