### PR TITLE
fix(ci): use organization APT_REPO_PAT secret

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -162,7 +162,7 @@ jobs:
         if: steps.check.outputs.action == 'create'
         uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{ secrets.REPO_DISPATCH_PAT }}
+          token: ${{ secrets.APT_REPO_PAT }}
           repository: hatlabs/apt.hatlabs.fi
           event-type: package-updated
           client-payload: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Trigger APT repository
         uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{ secrets.REPO_DISPATCH_PAT }}
+          token: ${{ secrets.APT_REPO_PAT }}
           repository: hatlabs/apt.hatlabs.fi
           event-type: package-updated
           client-payload: |


### PR DESCRIPTION
## Problem

The workflow is using `REPO_DISPATCH_PAT` which is not configured, but the organization has an `APT_REPO_PAT` secret that should be used instead.

## Solution

Update both `main.yml` and `release.yml` workflows to use the organization-wide `APT_REPO_PAT` secret instead of the repository-specific `REPO_DISPATCH_PAT`.

## Changes

- `.github/workflows/main.yml`: Changed `secrets.REPO_DISPATCH_PAT` → `secrets.APT_REPO_PAT`
- `.github/workflows/release.yml`: Changed `secrets.REPO_DISPATCH_PAT` → `secrets.APT_REPO_PAT`

## Benefits

- Uses existing organization secret (no need to create repository-specific secret)
- Consistent with other repositories in the organization
- Enables APT repository dispatch to work correctly

Fixes: https://github.com/hatlabs/halos-marine-containers/actions/runs/19551282574/job/55983203941