### PR TITLE
fix(signalk): add missing docker-compose version field

### DIFF
--- a/apps/signalk-server/docker-compose.yml
+++ b/apps/signalk-server/docker-compose.yml
@@ -1,3 +1,5 @@
+version: '3.8'
+
 services:
   signalk-server:
     image: cr.signalk.io/signalk/signalk-server:v2.18.0


### PR DESCRIPTION
## Summary

Add missing `version: '3.8'` to signalk-server docker-compose.yml for consistency with other docker-compose files.

The version field was accidentally removed in the previous refactoring PR.

## Test plan

- [ ] Verify docker-compose parses correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)