### PR TITLE
refactor(signalk): remove docker socket and binary mounts

### DIFF
--- a/apps/signalk-server/docker-compose.yml
+++ b/apps/signalk-server/docker-compose.yml
@@ -11,8 +11,6 @@ services:
     volumes:
       - ${CONTAINER_DATA_ROOT}/data:/home/node/.signalk
       - /dev:/dev
-      - /var/run/docker.sock:/var/run/docker.sock
-      - /usr/bin/docker:/usr/bin/docker
       - /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket
     privileged: true
     security_opt:


### PR DESCRIPTION
## Summary

Temporarily remove docker socket and binary mounts from Signal K container.

## Changes

- Remove `/var/run/docker.sock:/var/run/docker.sock` mount
- Remove `/usr/bin/docker:/usr/bin/docker` mount

## Test plan

- [ ] Verify Signal K starts correctly without docker access
- [ ] Confirm plugins that don't require docker still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)