### PR TITLE
feat(ci): skip build when version already released

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,11 +6,12 @@ on:
 
 jobs:
   build-release:
-    uses: hatlabs/shared-workflows/.github/workflows/build-release.yml@main
+    uses: hatlabs/shared-workflows/.github/workflows/build-release.yml@feat/skip-if-version-released
     with:
       package-name: marine-container-store
       package-description: 'Marine container store and curated marine application definitions'
       apt-distro: trixie
       apt-component: main
+      skip-if-version-released: true
     secrets:
       APT_REPO_PAT: ${{ secrets.APT_REPO_PAT }}


### PR DESCRIPTION
## Summary

Enable the new `skip-if-version-released` option to prevent auto-incrementing the revision number on every push to main.

## Problem

Currently, every push to main creates a new marine-container-store package release, even if only app definitions changed. This was not the intended behavior.

## Solution

Use the new shared-workflow option to skip builds when a release already exists for the current VERSION. The package will only be rebuilt when VERSION is explicitly bumped.

**Note**: This PR temporarily points to the feature branch `feat/skip-if-version-released` in shared-workflows. Once https://github.com/hatlabs/shared-workflows/pull/4 is merged, this should be updated to point to `main`.

## Test plan

- [ ] Push to this branch triggers workflow
- [ ] Workflow should skip build because v0.1.1+* tags exist
- [ ] "Build Skipped" message appears in workflow logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)