### PR TITLE
fix(ci): bust Docker cache when container-packaging-tools updates

### DIFF
--- a/.github/actions/build-deb/action.yml
+++ b/.github/actions/build-deb/action.yml
@@ -7,6 +7,14 @@ runs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
+    - name: Get container-packaging-tools version
+      id: tools-version
+      shell: bash
+      run: |
+        VERSION=$(curl -s https://api.github.com/repos/hatlabs/container-packaging-tools/releases/latest | jq -r '.tag_name')
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        echo "Using container-packaging-tools: $VERSION"
+
     - name: Build Docker image
       uses: docker/build-push-action@v5
       with:
@@ -16,6 +24,8 @@ runs:
         load: true
         cache-from: type=gha
         cache-to: type=gha,mode=max
+        build-args: |
+          CONTAINER_TOOLS_VERSION=${{ steps.tools-version.outputs.version }}
 
     - name: Build packages in Docker
       shell: bash

--- a/docker/Dockerfile.build
+++ b/docker/Dockerfile.build
@@ -1,5 +1,9 @@
 FROM debian:trixie
 
+# Cache-buster: update this when container-packaging-tools is updated
+# This ARG is set by CI to the latest release tag
+ARG CONTAINER_TOOLS_VERSION=latest
+
 # Install Debian packaging tools and dependencies
 RUN apt-get update && apt-get install -y \
     debhelper \
@@ -17,7 +21,9 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Install container-packaging-tools from GitHub releases
-RUN ASSET_URL=$(curl -s https://api.github.com/repos/hatlabs/container-packaging-tools/releases/latest | \
+# Note: The echo of CONTAINER_TOOLS_VERSION busts the Docker cache when the version changes
+RUN echo "Installing container-packaging-tools version: ${CONTAINER_TOOLS_VERSION}" && \
+    ASSET_URL=$(curl -s https://api.github.com/repos/hatlabs/container-packaging-tools/releases/latest | \
       jq -r '.assets[] | select(.name | endswith(".deb")) | .browser_download_url') && \
     if [ -z "$ASSET_URL" ]; then \
       echo "Error: Could not find .deb asset in latest release" >&2; \


### PR DESCRIPTION
## Summary

- Add version-based cache busting for Docker builds
- Query latest container-packaging-tools release tag before build
- Pass version as build-arg to invalidate cache when tools are updated

## Problem

The Docker build was caching the layer that installs container-packaging-tools. When a new version of container-packaging-tools was released (e.g., with the `env.template` rename fix), the cached layer continued using the old version.

This caused the built packages to still have `.env.template` instead of `env.template`.

## Solution

Pass the latest container-packaging-tools version as a Docker build-arg. When the version changes, Docker sees a different ARG value and invalidates the cache for that layer.

## Test plan

- [ ] CI builds pass
- [ ] Verify built packages contain `env.template` (without dot prefix)
- [ ] Verify built packages contain `env.user-template` (without dot prefix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)