### PR TITLE
chore(apps): bump revision for all container apps

### DIFF
--- a/apps/avnav/metadata.yaml
+++ b/apps/avnav/metadata.yaml
@@ -1,6 +1,6 @@
 name: AvNav
 package_name: avnav-container
-version: 20240520-1
+version: 20240520-2
 upstream_version: "20240520"
 description: Touch-optimized chart plotter for sailing and motor yachts
 long_description: |

--- a/apps/grafana/metadata.yaml
+++ b/apps/grafana/metadata.yaml
@@ -1,6 +1,6 @@
 name: Grafana
 package_name: grafana-container
-version: 12.1.4-1
+version: 12.1.4-2
 upstream_version: 12.1.4
 description: Data visualization and monitoring platform
 long_description: |

--- a/apps/influxdb/metadata.yaml
+++ b/apps/influxdb/metadata.yaml
@@ -1,6 +1,6 @@
 name: InfluxDB
 package_name: influxdb-container
-version: 2.7.12-1
+version: 2.7.12-2
 upstream_version: 2.7.12
 description: Time-series database for marine data logging
 long_description: |

--- a/apps/opencpn/metadata.yaml
+++ b/apps/opencpn/metadata.yaml
@@ -1,6 +1,6 @@
 name: OpenCPN
 package_name: opencpn-container
-version: 5.10.2-2
+version: 5.10.2-3
 upstream_version: 5.10.2
 description: Open source chart plotter and navigation software
 long_description: |

--- a/apps/signalk-server/metadata.yaml
+++ b/apps/signalk-server/metadata.yaml
@@ -1,6 +1,6 @@
 name: Signal K Server
 package_name: signalk-server-container
-version: 2.18.0-2
+version: 2.18.0-3
 upstream_version: 2.18.0
 description: Signal K server for marine data processing and routing
 long_description: |


### PR DESCRIPTION
## Summary

Bump revision for all container apps to rebuild with updated container-packaging-tools.

## Version bumps

| App | Old | New |
|-----|-----|-----|
| avnav | 20240520-1 | 20240520-2 |
| grafana | 12.1.4-1 | 12.1.4-2 |
| influxdb | 2.7.12-1 | 2.7.12-2 |
| opencpn | 5.10.2-2 | 5.10.2-3 |
| signalk-server | 2.18.0-2 | 2.18.0-3 |

## Changes included from container-packaging-tools

- Foreground service mode (`Type=simple` instead of `Type=oneshot`)
- Automatic restart on failure (`Restart=on-failure`)
- Better systemd/journal integration
- `env.template` naming fix (no dot prefix)

## Test plan

- [ ] CI builds pass
- [ ] Verify packages use foreground service mode
- [ ] Test on device: `systemctl status` shows "active (running)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)