### PR TITLE
fix(apps): remove obsolete version attribute from docker-compose files

### DIFF
--- a/apps/avnav/docker-compose.yml
+++ b/apps/avnav/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 
 services:
   avnav:

--- a/apps/avnav/metadata.yaml
+++ b/apps/avnav/metadata.yaml
@@ -1,6 +1,6 @@
 name: AvNav
 package_name: avnav-container
-version: 20240520-3
+version: 20240520-4
 upstream_version: "20240520"
 description: Touch-optimized chart plotter for sailing and motor yachts
 long_description: |

--- a/apps/grafana/docker-compose.yml
+++ b/apps/grafana/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 
 services:
   grafana:

--- a/apps/grafana/metadata.yaml
+++ b/apps/grafana/metadata.yaml
@@ -1,6 +1,6 @@
 name: Grafana
 package_name: grafana-container
-version: 12.1.4-3
+version: 12.1.4-4
 upstream_version: 12.1.4
 description: Data visualization and monitoring platform
 long_description: |

--- a/apps/influxdb/docker-compose.yml
+++ b/apps/influxdb/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 
 services:
   influxdb:

--- a/apps/influxdb/metadata.yaml
+++ b/apps/influxdb/metadata.yaml
@@ -1,6 +1,6 @@
 name: InfluxDB
 package_name: influxdb-container
-version: 2.7.12-3
+version: 2.7.12-4
 upstream_version: 2.7.12
 description: Time-series database for marine data logging
 long_description: |

--- a/apps/opencpn/docker-compose.yml
+++ b/apps/opencpn/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 
 services:
   opencpn:

--- a/apps/opencpn/metadata.yaml
+++ b/apps/opencpn/metadata.yaml
@@ -1,6 +1,6 @@
 name: OpenCPN
 package_name: opencpn-container
-version: 5.10.2-4
+version: 5.10.2-5
 upstream_version: 5.10.2
 description: Open source chart plotter and navigation software
 long_description: |

--- a/apps/signalk-server/docker-compose.yml
+++ b/apps/signalk-server/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 
 services:
   signalk-server:

--- a/apps/signalk-server/metadata.yaml
+++ b/apps/signalk-server/metadata.yaml
@@ -1,6 +1,6 @@
 name: Signal K Server
 package_name: signalk-server-container
-version: 2.18.0-4
+version: 2.18.0-5
 upstream_version: 2.18.0
 description: Signal K server for marine data processing and routing
 long_description: |


### PR DESCRIPTION
## Summary

Remove obsolete `version` attribute from all docker-compose.yml files.

## Problem

The `version` attribute is obsolete in modern Docker Compose (v2+) and triggers a warning:

```
WARN[0000] docker-compose.yml: the attribute `version` is obsolete...
```

This warning is output with ANSI color codes (yellow), which appear as `[NB blob data]` in journalctl.

## Solution

Simply remove the `version` attribute from all compose files. Docker Compose v2+ doesn't need it.

## Test plan

- [ ] CI builds pass
- [ ] Verify no warning on `docker compose up`

🤖 Generated with [Claude Code](https://claude.com/claude-code)