### PR TITLE
fix(grafana): bump version to 12.1.4-5

### DIFF
--- a/apps/grafana/metadata.yaml
+++ b/apps/grafana/metadata.yaml
@@ -1,6 +1,6 @@
 name: Grafana
 package_name: grafana-container
-version: 12.1.4-1
+version: 12.1.4-5
 upstream_version: 12.1.4
 description: Data visualization and monitoring platform
 long_description: |


### PR DESCRIPTION
Bumps version to 12.1.4-5 to supersede old 12.1.4-4 package in APT repo.

The old 12.1.4-4 package with wrong image (`grafana-oss`) is still in the APT repo, and 12.1.4-4 > 12.1.4-1 in Debian versioning, so apt won't upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)