### PR TITLE
fix(opencpn): change default port to 3021 (HTTPS)

### DIFF
--- a/apps/opencpn/docker-compose.yml
+++ b/apps/opencpn/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     container_name: opencpn
     restart: no
     ports:
-      - "${OPENCPN_PORT:-3002}:3001"
+      - "${OPENCPN_PORT:-3021}:3001"
     volumes:
       - ${CONTAINER_DATA_ROOT}/config:/config
     environment:

--- a/apps/opencpn/metadata.yaml
+++ b/apps/opencpn/metadata.yaml
@@ -1,6 +1,6 @@
 name: OpenCPN
 package_name: opencpn-container
-version: 5.12.4-2
+version: 5.12.4-3
 upstream_version: 5.12.4
 description: Open source chart plotter and navigation software
 long_description: |
@@ -37,7 +37,7 @@ depends:
 web_ui:
   enabled: true
   path: /
-  port: 3002
-  protocol: http
+  port: 3021
+  protocol: https
 default_config:
-  OPENCPN_PORT: "3002"
+  OPENCPN_PORT: "3021"


### PR DESCRIPTION
## Summary

- Change OpenCPN default port from 3002 to 3021
- Switch protocol from HTTP to HTTPS

## Test plan

- [ ] CI checks pass
- [ ] Package builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)