### PR TITLE
feat(apps): apply container lifecycle conventions

### DIFF
--- a/apps/avnav/docker-compose.yml
+++ b/apps/avnav/docker-compose.yml
@@ -3,7 +3,11 @@ services:
   avnav:
     image: xfreex/avnav-stable:20251028
     container_name: avnav
-    restart: no
+    restart: unless-stopped
+    logging:
+      driver: journald
+      options:
+        tag: "{{.Name}}"
     ports:
       - "${AVNAV_HTTP_PORT:-3011}:8080"
       - "${AVNAV_WEBSOCKET_PORT:-8083}:8083"

--- a/apps/grafana/docker-compose.yml
+++ b/apps/grafana/docker-compose.yml
@@ -3,7 +3,11 @@ services:
   grafana:
     image: grafana/grafana:12.1.4
     container_name: grafana
-    restart: no
+    restart: unless-stopped
+    logging:
+      driver: journald
+      options:
+        tag: "{{.Name}}"
     ports:
       - "${GRAFANA_PORT:-3001}:3000"
     volumes:

--- a/apps/influxdb/docker-compose.yml
+++ b/apps/influxdb/docker-compose.yml
@@ -3,7 +3,11 @@ services:
   influxdb:
     image: influxdb:2.7.12
     container_name: influxdb
-    restart: no
+    restart: unless-stopped
+    logging:
+      driver: journald
+      options:
+        tag: "{{.Name}}"
     ports:
       - "${INFLUXDB_PORT:-8086}:8086"
     volumes:

--- a/apps/opencpn/docker-compose.yml
+++ b/apps/opencpn/docker-compose.yml
@@ -3,7 +3,11 @@ services:
   opencpn:
     image: ghcr.io/hatlabs/opencpn-docker:5.12.4
     container_name: opencpn
-    restart: no
+    restart: unless-stopped
+    logging:
+      driver: journald
+      options:
+        tag: "{{.Name}}"
     ports:
       - "${OPENCPN_PORT:-3021}:3001"
     volumes:

--- a/apps/signalk-server/docker-compose.yml
+++ b/apps/signalk-server/docker-compose.yml
@@ -3,7 +3,11 @@ services:
   signalk-server:
     image: cr.signalk.io/signalk/signalk-server:v2.18.0
     container_name: signalk-server
-    restart: no
+    restart: unless-stopped
+    logging:
+      driver: journald
+      options:
+        tag: "{{.Name}}"
     network_mode: host
     environment:
       - NODE_NO_WARNINGS=1
@@ -16,6 +20,3 @@ services:
       - no-new-privileges:false
     cap_add:
       - NET_ADMIN
-    logging:
-      options:
-        max-size: 10m


### PR DESCRIPTION
## Summary

- Apply new container lifecycle conventions to all marine apps (avnav, grafana, influxdb, opencpn, signalk-server)
- Change restart policy from `no` to `unless-stopped` - Docker handles per-container restarts
- Add journald logging driver for unified logging with per-container filtering
- Remove old max-size logging option from signalk-server

## Benefits

| Concern | Solution |
|---------|----------|
| Container crash recovery | Docker handles it (fast, per-container) |
| Service-level failures | systemd handles it (fallback) |
| Unified logging | journald (one place, `journalctl -u <service>`) |
| Per-container filtering | journald metadata (`journalctl CONTAINER_NAME=x`) |
| No log duplication | journald driver replaces json-file |

## Test plan

- [ ] Verify packages build successfully in CI
- [ ] Verify containers start with new restart policy
- [ ] Verify logs appear in journalctl with correct container names

Part of hatlabs/halos-distro#49

🤖 Generated with [Claude Code](https://claude.com/claude-code)