### PR TITLE
fix(apps): add required app_id field to all metadata files

### DIFF
--- a/apps/avnav/metadata.yaml
+++ b/apps/avnav/metadata.yaml
@@ -1,4 +1,5 @@
 name: AvNav
+app_id: avnav
 version: 20251028-2
 upstream_version: "20251028"
 description: Touch-optimized chart plotter for sailing and motor yachts

--- a/apps/grafana/metadata.yaml
+++ b/apps/grafana/metadata.yaml
@@ -1,4 +1,5 @@
 name: Grafana
+app_id: grafana
 version: 12.1.4-6
 upstream_version: 12.1.4
 description: Data visualization and monitoring platform

--- a/apps/influxdb/metadata.yaml
+++ b/apps/influxdb/metadata.yaml
@@ -1,4 +1,5 @@
 name: InfluxDB
+app_id: influxdb
 version: 2.7.12-5
 upstream_version: 2.7.12
 description: Time-series database for marine data logging

--- a/apps/opencpn/metadata.yaml
+++ b/apps/opencpn/metadata.yaml
@@ -1,4 +1,5 @@
 name: OpenCPN
+app_id: opencpn
 version: 5.12.4-3
 upstream_version: 5.12.4
 description: Open source chart plotter and navigation software

--- a/apps/signalk-server/metadata.yaml
+++ b/apps/signalk-server/metadata.yaml
@@ -1,4 +1,5 @@
 name: Signal K Server
+app_id: signalk-server
 version: 2.18.0-6
 upstream_version: 2.18.0
 description: Signal K server for marine data processing and routing


### PR DESCRIPTION
## Summary

Add `app_id` field to all 5 marine app metadata files:
- avnav
- grafana
- influxdb
- opencpn
- signalk-server

## Background

The `app_id` field is now mandatory in container-packaging-tools after hatlabs/container-packaging-tools#128. Without this field, builds will fail with schema validation errors.

## Test plan

- [ ] CI passes - build should complete successfully with the new c-p-t

🤖 Generated with [Claude Code](https://claude.com/claude-code)