### PR TITLE
fix(signalk): add prestart.sh to set data directory ownership

### DIFF
--- a/apps/signalk-server/metadata.yaml
+++ b/apps/signalk-server/metadata.yaml
@@ -1,6 +1,6 @@
 name: Signal K Server
 app_id: signalk-server
-version: 2.18.0-6
+version: 2.18.0-7
 upstream_version: 2.18.0
 description: Signal K server for marine data processing and routing
 long_description: |

--- a/apps/signalk-server/prestart.sh
+++ b/apps/signalk-server/prestart.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Prestart script for signalk-server-container
+# Sets correct ownership on data directory for the node user
+set -e
+
+# Derive package name from script location
+# Script is at /var/lib/container-apps/<package-name>/prestart.sh
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PACKAGE_NAME="$(basename "$SCRIPT_DIR")"
+ETC_DIR="/etc/container-apps/${PACKAGE_NAME}"
+
+# Load config values from env files
+set -a
+[ -f "${ETC_DIR}/env.defaults" ] && . "${ETC_DIR}/env.defaults"
+[ -f "${ETC_DIR}/env" ] && . "${ETC_DIR}/env"
+set +a
+
+# Ensure data directory has correct ownership
+# Signal K runs as user 'node' (UID 1000 by default)
+# PUID/PGID are set in env.defaults
+if [ -n "$CONTAINER_DATA_ROOT" ] && [ -d "$CONTAINER_DATA_ROOT" ]; then
+    chown -R "${PUID:-1000}:${PGID:-1000}" "$CONTAINER_DATA_ROOT"
+    echo "Set ownership of $CONTAINER_DATA_ROOT to ${PUID:-1000}:${PGID:-1000}"
+fi


### PR DESCRIPTION
## Summary

- Add prestart.sh script that sets correct ownership on Signal K data directory
- Bump version to 2.18.0-7

## Problem

The Signal K container runs as user `node` (UID 1000) but the data directory at `/var/lib/container-apps/marine-signalk-server-container/data/` was created with `root:root` ownership by the systemd service's `mkdir -p` commands.

This caused permission denied errors on startup:
```
Error: EACCES: permission denied, open '/home/node/.signalk/package.json'
```

## Solution

Added a `prestart.sh` script that:
1. Derives package name from script location (portable, same pattern as Homarr fix)
2. Sources env.defaults to get PUID/PGID (1000:1000) and CONTAINER_DATA_ROOT
3. Runs `chown -R` to set correct ownership before container starts

## Test plan

- [x] Manual fix verified on halos.local
- [ ] CI builds package successfully
- [ ] Fresh install sets correct ownership

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)