### PR TITLE
chore(ci): add workflow_dispatch for manual triggering

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,7 @@ name: Main Branch CI/CD
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   build-release:


### PR DESCRIPTION
## Summary

- Add `workflow_dispatch` trigger to main branch CI/CD workflow
- Enables manual workflow runs from GitHub Actions UI

This also serves to trigger a package rebuild with the latest container-packaging-tools changes (UID/GID detection, Homarr labels, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)