### PR TITLE
chore: bump app versions for homarr.icon labels

### DIFF
--- a/apps/avnav/metadata.yaml
+++ b/apps/avnav/metadata.yaml
@@ -1,6 +1,6 @@
 name: AvNav
 app_id: avnav
-version: 20251028-2
+version: 20251028-3
 upstream_version: "20251028"
 description: Touch-optimized chart plotter for sailing and motor yachts
 long_description: |

--- a/apps/grafana/metadata.yaml
+++ b/apps/grafana/metadata.yaml
@@ -1,6 +1,6 @@
 name: Grafana
 app_id: grafana
-version: 12.1.4-6
+version: 12.1.4-7
 upstream_version: 12.1.4
 description: Data visualization and monitoring platform
 long_description: |

--- a/apps/influxdb/metadata.yaml
+++ b/apps/influxdb/metadata.yaml
@@ -1,6 +1,6 @@
 name: InfluxDB
 app_id: influxdb
-version: 2.7.12-5
+version: 2.7.12-6
 upstream_version: 2.7.12
 description: Time-series database for marine data logging
 long_description: |

--- a/apps/opencpn/metadata.yaml
+++ b/apps/opencpn/metadata.yaml
@@ -1,6 +1,6 @@
 name: OpenCPN
 app_id: opencpn
-version: 5.12.4-3
+version: 5.12.4-4
 upstream_version: 5.12.4
 description: Open source chart plotter and navigation software
 long_description: |

--- a/apps/signalk-server/metadata.yaml
+++ b/apps/signalk-server/metadata.yaml
@@ -1,6 +1,6 @@
 name: Signal K Server
 app_id: signalk-server
-version: 2.18.0-6
+version: 2.18.0-7
 upstream_version: 2.18.0
 description: Signal K server for marine data processing and routing
 long_description: |


### PR DESCRIPTION
## Summary
Bump revision for all marine container apps to trigger new package builds with the `homarr.icon` label changes from #60.

## Changes
| App | Old Version | New Version |
|-----|-------------|-------------|
| avnav | 20251028-2 | 20251028-3 |
| grafana | 12.1.4-6 | 12.1.4-7 |
| influxdb | 2.7.12-5 | 2.7.12-6 |
| opencpn | 5.12.4-3 | 5.12.4-4 |
| signalk-server | 2.18.0-6 | 2.18.0-7 |

## Test plan
- [ ] CI builds succeed
- [ ] New package versions appear in APT repository after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)