### PR TITLE
fix: remove manual homarr.icon labels from docker-compose files

### DIFF
--- a/apps/avnav/docker-compose.yml
+++ b/apps/avnav/docker-compose.yml
@@ -22,8 +22,6 @@ services:
     privileged: true
     networks:
       - avnav-net
-    labels:
-      homarr.icon: /usr/share/pixmaps/marine-avnav-container.png
 
 networks:
   avnav-net:

--- a/apps/grafana/docker-compose.yml
+++ b/apps/grafana/docker-compose.yml
@@ -14,8 +14,6 @@ services:
       - ${CONTAINER_DATA_ROOT}/data:/var/lib/grafana
     networks:
       - grafana-net
-    labels:
-      homarr.icon: /usr/share/pixmaps/marine-grafana-container.svg
 
 networks:
   grafana-net:

--- a/apps/influxdb/docker-compose.yml
+++ b/apps/influxdb/docker-compose.yml
@@ -24,8 +24,6 @@ services:
       - DOCKER_INFLUXD_QUERY_MEMORY_BYTES=20971520
     networks:
       - influxdb-net
-    labels:
-      homarr.icon: /usr/share/pixmaps/marine-influxdb-container.svg
 
 networks:
   influxdb-net:

--- a/apps/opencpn/docker-compose.yml
+++ b/apps/opencpn/docker-compose.yml
@@ -20,8 +20,6 @@ services:
     shm_size: 1gb
     networks:
       - opencpn-net
-    labels:
-      homarr.icon: /usr/share/pixmaps/marine-opencpn-container.png
 
 networks:
   opencpn-net:

--- a/apps/signalk-server/docker-compose.yml
+++ b/apps/signalk-server/docker-compose.yml
@@ -20,5 +20,3 @@ services:
       - no-new-privileges:false
     cap_add:
       - NET_ADMIN
-    labels:
-      homarr.icon: /usr/share/pixmaps/marine-signalk-server-container.svg


### PR DESCRIPTION
## Summary
- Remove manual `homarr.icon` labels from all docker-compose.yml files
- Let container-packaging-tools auto-generate correct icon paths based on package name

## Problem
The container-packaging-tools auto-generates all `homarr.*` labels including `homarr.icon` based on the package name. However, manual labels in docker-compose.yml take precedence (existing labels are preserved, not overwritten).

This caused icon path mismatches - e.g., docker-compose.yml specified `marine-influxdb-container.svg` but the actual icon file was `influxdb-container.svg`.

## Solution
Remove manual `homarr.icon` labels and let the packaging tools generate them correctly.

## Test plan
- [ ] Rebuild affected packages
- [ ] Verify icons appear correctly in Homarr dashboard
- [ ] Verify auto-generated icon paths match actual file names

🤖 Generated with [Claude Code](https://claude.com/claude-code)