### PR TITLE
fix(grafana): resolve startup failure due to data directory permissions

### DIFF
--- a/apps/grafana/docker-compose.yml
+++ b/apps/grafana/docker-compose.yml
@@ -3,6 +3,7 @@ services:
   grafana:
     image: grafana/grafana:12.1.4
     container_name: grafana
+    user: "472"
     restart: unless-stopped
     logging:
       driver: journald

--- a/apps/grafana/metadata.yaml
+++ b/apps/grafana/metadata.yaml
@@ -1,6 +1,6 @@
 name: Grafana
 app_id: grafana
-version: 12.1.4-7
+version: 12.1.4-8
 upstream_version: 12.1.4
 description: Data visualization and monitoring platform
 long_description: |


### PR DESCRIPTION
## Summary

Fix Grafana container startup failure due to data directory permissions.

### Problem

The Grafana container was failing to start because:
1. Docker creates volume mount directories as root
2. Grafana runs as UID 472 inside the container
3. The container couldn't write to the root-owned data directory

### Solution

Add `user: "472"` to docker-compose.yml. This tells container-packaging-tools to generate the postinst script with `chown 472` for the data directory.

**Files changed:** `apps/grafana/docker-compose.yml`, `apps/grafana/metadata.yaml`

## Test plan

- [x] Verified on halos.local - Grafana container starts successfully
- [x] Data directory has correct ownership (472)
- [x] Homarr shows Grafana icon (not Docker whale fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)