### PR TITLE
feat(metadata): enable visibility for marine apps

### DIFF
--- a/apps/avnav/metadata.yaml
+++ b/apps/avnav/metadata.yaml
@@ -39,5 +39,6 @@ web_ui:
   path: /
   port: 8082
   protocol: http
+  visible: true
 default_config:
   AVNAV_HTTP_PORT: "8082"

--- a/apps/grafana/metadata.yaml
+++ b/apps/grafana/metadata.yaml
@@ -36,6 +36,7 @@ web_ui:
   path: /
   port: 3001
   protocol: http
+  visible: true
 default_config:
   GRAFANA_PORT: "3001"
   GRAFANA_ADMIN_USER: admin

--- a/apps/influxdb/metadata.yaml
+++ b/apps/influxdb/metadata.yaml
@@ -33,6 +33,7 @@ web_ui:
   path: /
   port: 8086
   protocol: http
+  visible: true
 default_config:
   INFLUXDB_HTTP_PORT: "8086"
   INFLUXDB_ADMIN_USER: admin

--- a/apps/opencpn/metadata.yaml
+++ b/apps/opencpn/metadata.yaml
@@ -38,5 +38,6 @@ web_ui:
   path: /
   port: 3021
   protocol: https
+  visible: true
 default_config:
   OPENCPN_PORT: "3021"

--- a/apps/signalk-server/metadata.yaml
+++ b/apps/signalk-server/metadata.yaml
@@ -34,6 +34,7 @@ web_ui:
   path: /
   port: 3000
   protocol: http
+  visible: true
 default_config:
   SIGNALK_PORT: "3000"
   SIGNALK_ADMIN_USER: admin


### PR DESCRIPTION
## Summary

Add `visible: true` to all marine app metadata so they appear on Homarr dashboards:
- AvNav
- Grafana
- InfluxDB
- OpenCPN
- Signal K Server

## Related PRs

- hatlabs/homarr-container-adapter#36 - Visibility filtering in adapter
- hatlabs/container-packaging-tools#143 - `visible` field in schema

## Test plan

- [x] Tested on halos.local - all 5 marine apps appear on dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)