### PR TITLE
feat(layout): add dashboard layout to Signal K and AvNav

### DIFF
--- a/apps/avnav/metadata.yaml
+++ b/apps/avnav/metadata.yaml
@@ -42,3 +42,9 @@ web_ui:
   visible: true
 default_config:
   AVNAV_HTTP_PORT: "8082"
+layout:
+  priority: 50
+  width: 2
+  height: 2
+  x_offset: 2
+  y_offset: 0

--- a/apps/signalk-server/metadata.yaml
+++ b/apps/signalk-server/metadata.yaml
@@ -35,6 +35,12 @@ web_ui:
   port: 3000
   protocol: http
   visible: true
+layout:
+  priority: 40
+  width: 2
+  height: 2
+  x_offset: 0
+  y_offset: 1
 default_config:
   SIGNALK_PORT: "3000"
   SIGNALK_ADMIN_USER: admin


### PR DESCRIPTION
## Summary

- Add layout configuration to Signal K and AvNav metadata.yaml files
- Configures Homarr dashboard card positions and sizes

### Layout Configuration

| App | Priority | Size | Position |
|-----|----------|------|----------|
| Signal K | 40 | 2x2 | (0, 1) |
| AvNav | 50 | 2x2 | (2, 0) |

## Dependencies

- Requires hatlabs/container-packaging-tools#145 (layout schema support)

## Test plan

- [x] Tested on halos.local

🤖 Generated with [Claude Code](https://claude.com/claude-code)