### PR TITLE
chore: bump signalk-server and avnav revisions

### DIFF
--- a/apps/avnav/metadata.yaml
+++ b/apps/avnav/metadata.yaml
@@ -1,6 +1,6 @@
 name: AvNav
 app_id: avnav
-version: 20251028-3
+version: 20251028-4
 upstream_version: "20251028"
 description: Touch-optimized chart plotter for sailing and motor yachts
 long_description: |

--- a/apps/signalk-server/metadata.yaml
+++ b/apps/signalk-server/metadata.yaml
@@ -1,6 +1,6 @@
 name: Signal K Server
 app_id: signalk-server
-version: 2.18.0-7
+version: 2.18.0-8
 upstream_version: 2.18.0
 description: Signal K server for marine data processing and routing
 long_description: |


### PR DESCRIPTION
## Summary

Bump package revisions after layout configuration changes:

- signalk-server: 2.18.0-7 → 2.18.0-8
- avnav: 20251028-3 → 20251028-4

## Test plan

- [ ] CI builds packages successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)