### PR TITLE
feat(store): add role::container-store tag for discovery

### DIFF
--- a/store/debian/changelog
+++ b/store/debian/changelog
@@ -1,3 +1,10 @@
+marine-container-store (0.2.1-1) stable; urgency=medium
+
+  * Add role::container-store tag for store discovery
+  * Enables cockpit-container-apps store editor feature
+
+ -- Hat Labs <info@hatlabs.fi>  Mon, 23 Dec 2024 12:00:00 +0200
+
 marine-container-store (0.2.0-1) stable; urgency=medium
 
   * Add repository origin filter to restrict packages to Hat Labs only

--- a/store/debian/control
+++ b/store/debian/control
@@ -8,6 +8,7 @@ Homepage: https://github.com/hatlabs/halos-marine-containers
 
 Package: marine-container-store
 Architecture: all
+Tag: role::container-store
 Description: Marine container application store definition for Cockpit APT
  This package provides the store definition and branding for the Marine
  container application store, designed to work with cockpit-apt.


### PR DESCRIPTION
## Summary

- Add `Tag: role::container-store` to marine-container-store package control file
- This tag enables the store editor feature in cockpit-container-apps to discover and list available container stores

## Related

- Closes hatlabs/cockpit-container-apps#56
- Part of the container store editor feature implementation

## Test plan

- [ ] Verify the package builds successfully
- [ ] Verify the tag is present in the built package

🤖 Generated with [Claude Code](https://claude.com/claude-code)