### PR TITLE
docs(store): update description to reference cockpit-container-apps

### DIFF
--- a/store/debian/changelog
+++ b/store/debian/changelog
@@ -1,3 +1,9 @@
+marine-container-store (0.2.2-1) stable; urgency=medium
+
+  * Update package description to reference cockpit-container-apps
+
+ -- Hat Labs <info@hatlabs.fi>  Mon, 23 Dec 2024 14:00:00 +0200
+
 marine-container-store (0.2.1-1) stable; urgency=medium
 
   * Add role::container-store tag for store discovery

--- a/store/debian/control
+++ b/store/debian/control
@@ -9,13 +9,13 @@ Homepage: https://github.com/hatlabs/halos-marine-containers
 Package: marine-container-store
 Architecture: all
 Tag: role::container-store
-Description: Marine container application store definition for Cockpit APT
+Description: Marine container application store for Cockpit Container Apps
  This package provides the store definition and branding for the Marine
- container application store, designed to work with cockpit-apt.
+ container application store, designed to work with cockpit-container-apps.
  .
- When installed alongside cockpit-apt, it enables a curated view of marine
- and sailing applications including navigation software, chart plotters,
- weather routing, data logging, and monitoring dashboards.
+ When installed alongside cockpit-container-apps, it enables a curated
+ view of marine and sailing applications including navigation software,
+ chart plotters, weather routing, data logging, and monitoring dashboards.
  .
  The store filters packages from apt.hatlabs.fi and other repositories
  based on Debian tags (debtags), sections, and package metadata.


### PR DESCRIPTION
Update package description to reference cockpit-container-apps instead of cockpit-apt.