### PR TITLE
feat(routing): add proxy-agnostic routing configuration to marine apps

### DIFF
--- a/apps/avnav/metadata.yaml
+++ b/apps/avnav/metadata.yaml
@@ -40,9 +40,10 @@ web_ui:
   port: 8082
   protocol: http
   visible: true
-traefik:
+routing:
   subdomain: avnav
-  auth: none
+  auth:
+    mode: none
 default_config:
   AVNAV_HTTP_PORT: "8082"
 layout:

--- a/apps/grafana/metadata.yaml
+++ b/apps/grafana/metadata.yaml
@@ -37,13 +37,14 @@ web_ui:
   port: 3001
   protocol: http
   visible: true
-traefik:
+routing:
   subdomain: grafana
-  auth: forward_auth
-  forward_auth:
-    headers:
-      Remote-User: X-WEBAUTH-USER
-      Remote-Groups: X-WEBAUTH-GROUPS
+  auth:
+    mode: forward_auth
+    forward_auth:
+      headers:
+        Remote-User: X-WEBAUTH-USER
+        Remote-Groups: X-WEBAUTH-GROUPS
 default_config:
   GRAFANA_PORT: "3001"
   GRAFANA_ADMIN_USER: admin

--- a/apps/influxdb/metadata.yaml
+++ b/apps/influxdb/metadata.yaml
@@ -34,9 +34,10 @@ web_ui:
   port: 8086
   protocol: http
   visible: true
-traefik:
+routing:
   subdomain: influxdb
-  auth: none
+  auth:
+    mode: none
 default_config:
   INFLUXDB_HTTP_PORT: "8086"
   INFLUXDB_ADMIN_USER: admin

--- a/apps/opencpn/metadata.yaml
+++ b/apps/opencpn/metadata.yaml
@@ -39,8 +39,9 @@ web_ui:
   port: 3021
   protocol: https
   visible: true
-traefik:
+routing:
   subdomain: opencpn
-  auth: none
+  auth:
+    mode: none
 default_config:
   OPENCPN_PORT: "3021"

--- a/apps/signalk-server/metadata.yaml
+++ b/apps/signalk-server/metadata.yaml
@@ -41,9 +41,10 @@ layout:
   height: 2
   x_offset: 0
   y_offset: 1
-traefik:
+routing:
   subdomain: signalk
-  auth: none
+  auth:
+    mode: none
   host_port: 3000
 default_config:
   SIGNALK_PORT: "3000"


### PR DESCRIPTION
## Summary

Adds routing configuration to all marine apps using the new proxy-agnostic `routing:` schema format.

### Apps Configured

| App | Subdomain | Auth Mode | Notes |
|-----|-----------|-----------|-------|
| grafana | grafana | forward_auth | Custom header mappings for Grafana auth |
| signalk-server | signalk | none | Host networking with port 3000 |
| avnav | avnav | none | |
| influxdb | influxdb | none | |
| opencpn | opencpn | none | |

### Routing Schema Format

The new `routing:` format is proxy-agnostic and will generate appropriate labels at runtime:

```yaml
routing:
  subdomain: grafana
  auth:
    mode: forward_auth
    forward_auth:
      headers:
        Remote-User: X-WEBAUTH-USER
```

### Dependencies

This PR requires container-packaging-tools to support the `routing:` schema format.

- Requires: hatlabs/container-packaging-tools#159 (routing.yml generation)

## Test plan

- [ ] Apps build successfully with new schema
- [ ] Routing is correctly generated
- [ ] Apps work behind Traefik reverse proxy

Part of: https://github.com/hatlabs/halos-distro/issues/59

🤖 Generated with [Claude Code](https://claude.com/claude-code)