### PR TITLE
fix(avnav): align docker-compose port default with default_config

### DIFF
--- a/apps/avnav/docker-compose.yml
+++ b/apps/avnav/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       options:
         tag: "{{.Name}}"
     ports:
-      - "${AVNAV_HTTP_PORT:-3011}:8080"
+      - "${AVNAV_HTTP_PORT:-8082}:8080"
       - "${AVNAV_WEBSOCKET_PORT:-8083}:8083"
       - "${AVNAV_NMEA_PORT:-34567}:34567"
     volumes:


### PR DESCRIPTION
## Summary

- Change HTTP port default from 3011 to 8082 to match the value in default_config.AVNAV_HTTP_PORT
- Ensures consistency between the docker-compose default and the configured default

## Test plan

- [ ] Verify AvNav container starts on port 8082 by default
- [ ] Verify existing configurations with custom AVNAV_HTTP_PORT still work

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)