### PR TITLE
revert: restore avnav default port to 3011

### DIFF
--- a/apps/avnav/docker-compose.yml
+++ b/apps/avnav/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       options:
         tag: "{{.Name}}"
     ports:
-      - "${AVNAV_HTTP_PORT:-8082}:8080"
+      - "${AVNAV_HTTP_PORT:-3011}:8080"
       - "${AVNAV_WEBSOCKET_PORT:-8083}:8083"
       - "${AVNAV_NMEA_PORT:-34567}:34567"
     volumes:


### PR DESCRIPTION
## Summary

Reverts the change from PR #78 which changed the default port from 3011 to 8082.

## Reason

The change was merged without proper approval. Reverting to restore the original default value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)