### PR TITLE
fix(grafana): enable auth proxy for SSO support

### DIFF
--- a/apps/grafana/docker-compose.yml
+++ b/apps/grafana/docker-compose.yml
@@ -5,6 +5,12 @@ services:
     container_name: grafana
     user: "472"
     restart: unless-stopped
+    environment:
+      # Enable auth proxy to accept X-WEBAUTH-USER header from ForwardAuth
+      GF_AUTH_PROXY_ENABLED: "true"
+      GF_AUTH_PROXY_HEADER_NAME: "X-WEBAUTH-USER"
+      GF_AUTH_PROXY_HEADER_PROPERTY: "username"
+      GF_AUTH_PROXY_AUTO_SIGN_UP: "true"
     logging:
       driver: journald
       options:

--- a/apps/grafana/metadata.yaml
+++ b/apps/grafana/metadata.yaml
@@ -1,6 +1,6 @@
 name: Grafana
 app_id: grafana
-version: 12.1.4-9
+version: 12.1.4-10
 upstream_version: 12.1.4
 description: Data visualization and monitoring platform
 long_description: |


### PR DESCRIPTION
## Summary

- Enable Grafana auth proxy configuration to accept `X-WEBAUTH-USER` header from Authelia ForwardAuth middleware
- Allows single sign-on authentication for Grafana through Authelia
- Bumps version to 12.1.4-10

## Test plan

- [x] Built new package using container-packaging-tools
- [x] Deployed to halos.hal test device
- [x] Verified auth proxy env vars are set in container
- [x] Tested auth proxy by sending `X-WEBAUTH-USER` header - Grafana correctly returns user with `authLabels: ["Auth Proxy"]`

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)