### PR TITLE
feat(apps): add 2x2 tile layout settings

### DIFF
--- a/apps/grafana/metadata.yaml
+++ b/apps/grafana/metadata.yaml
@@ -45,6 +45,10 @@ routing:
       headers:
         Remote-User: X-WEBAUTH-USER
         Remote-Groups: X-WEBAUTH-GROUPS
+layout:
+  priority: 50
+  width: 2
+  height: 2
 default_config:
   GRAFANA_PORT: "3001"
   GRAFANA_ADMIN_USER: admin

--- a/apps/influxdb/metadata.yaml
+++ b/apps/influxdb/metadata.yaml
@@ -38,6 +38,10 @@ routing:
   subdomain: influxdb
   auth:
     mode: none
+layout:
+  priority: 50
+  width: 2
+  height: 2
 default_config:
   INFLUXDB_HTTP_PORT: "8086"
   INFLUXDB_ADMIN_USER: admin

--- a/apps/opencpn/metadata.yaml
+++ b/apps/opencpn/metadata.yaml
@@ -43,5 +43,9 @@ routing:
   subdomain: opencpn
   auth:
     mode: none
+layout:
+  priority: 50
+  width: 2
+  height: 2
 default_config:
   OPENCPN_PORT: "3021"


### PR DESCRIPTION
## Summary
- Add explicit 2x2 tile layout settings for grafana, influxdb, and opencpn
- Matches existing layout settings in signalk-server and avnav
- Provides consistent tile sizing on the Homarr dashboard

## Test plan
- [ ] Verify packages build successfully
- [ ] Verify tiles appear as 2x2 on Homarr dashboard after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)