### PR TITLE
fix(opencpn): 400 Bad Request when accessing via Traefik

### DIFF
--- a/apps/opencpn/metadata.yaml
+++ b/apps/opencpn/metadata.yaml
@@ -1,6 +1,6 @@
 name: OpenCPN
 app_id: opencpn
-version: 5.12.4-6
+version: 5.12.4-7
 upstream_version: 5.12.4
 description: Open source chart plotter and navigation software
 long_description: |


### PR DESCRIPTION
## Summary

Bump OpenCPN version to trigger rebuild with new routing.yml that includes the `scheme: https` field.

## Background

OpenCPN uses selkies-gstreamer which expects HTTPS connections on port 3001. However, Traefik was sending HTTP to the backend container, causing 400 Bad Request errors with the message "The plain HTTP request was sent to HTTPS port".

## Solution

This fix requires changes across three repositories:

1. **container-packaging-tools#173**: Adds `scheme` field to routing.yml generation, reading from `web_ui.protocol` in metadata.yaml
2. **halos-core-containers#60**: Updates generate-routing-labels.sh to consume the scheme field and configure Traefik with `loadbalancer.server.scheme: https`
3. **This PR**: Version bump to generate new routing.yml with the scheme field

The OpenCPN metadata already has `web_ui.protocol: https`, so once container-packaging-tools is updated, the routing.yml will include `scheme: https` and Traefik will use HTTPS to connect to the backend.

## Dependencies

- [ ] hatlabs/container-packaging-tools#173 must be merged first
- [ ] hatlabs/halos-core-containers#60 must be merged first

## Test plan

After all PRs are merged:
- [ ] Build and install updated packages
- [ ] Access https://opencpn.halos.local/
- [ ] Verify no 400 Bad Request error
- [ ] Verify OpenCPN UI loads correctly

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)