### PR TITLE
fix(ci): clarify release notes include built packages

### DIFF
--- a/.github/scripts/generate-release-notes.sh
+++ b/.github/scripts/generate-release-notes.sh
@@ -82,7 +82,12 @@ ${CHANGELOG}
 
 ### Installation
 
-This is the source code release. For Debian packages, see [apt.hatlabs.fi](https://github.com/hatlabs/apt.hatlabs.fi).
+Built Debian packages are attached to this release and available from [apt.hatlabs.fi](https://github.com/hatlabs/apt.hatlabs.fi):
+
+\`\`\`bash
+sudo apt update
+sudo apt install marine-container-store
+\`\`\`
 
 ### Development
 
@@ -112,7 +117,12 @@ ${CHANGELOG}
 
 ### Installation
 
-This is the source code release. For Debian packages, see [apt.hatlabs.fi](https://github.com/hatlabs/apt.hatlabs.fi).
+Built Debian packages are attached to this release and available from [apt.hatlabs.fi](https://github.com/hatlabs/apt.hatlabs.fi):
+
+\`\`\`bash
+sudo apt update
+sudo apt install marine-container-store
+\`\`\`
 
 ### Development
 


### PR DESCRIPTION
## Summary

- Update release notes to clarify that .deb packages are attached to releases
- Add apt install command example

## Problem

The previous wording "This is the source code release" was misleading since releases include built .deb packages as artifacts.

## Test plan

- [ ] Next CI run should generate accurate release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)