### PR TITLE
fix(avnav): add routing.port for Traefik label generation

### DIFF
--- a/apps/avnav/metadata.yaml
+++ b/apps/avnav/metadata.yaml
@@ -1,6 +1,6 @@
 name: AvNav
 app_id: avnav
-version: 20251028-6
+version: 20251028-7
 upstream_version: "20251028"
 description: Touch-optimized chart plotter for sailing and motor yachts
 long_description: |
@@ -42,6 +42,7 @@ web_ui:
   visible: true
 routing:
   subdomain: avnav
+  port: 8080  # Main web UI port (not the exposed 8083 AvnavOchartsPro port)
   auth:
     mode: none
 layout:


### PR DESCRIPTION
## Summary

- Add explicit `routing.port: 8080` to avnav metadata.yaml
- Version bump to 20251028-7

## Problem

AvNav exposes multiple ports (8080 for main web UI, 8083 for AvnavOchartsPro). Without an explicit port specification in the routing config, Traefik may pick the wrong port for the loadbalancer.server.port label.

## Test plan

- [ ] Build updated package
- [ ] Verify generated docker-compose labels include correct port

🤖 Generated with [Claude Code](https://claude.com/claude-code)