### PR TITLE
feat(avnav): require Authelia authentication via ForwardAuth

### DIFF
--- a/apps/avnav/metadata.yaml
+++ b/apps/avnav/metadata.yaml
@@ -1,6 +1,6 @@
 name: AvNav
 app_id: avnav
-version: 20251028-7
+version: 20251028-8
 upstream_version: "20251028"
 description: Touch-optimized chart plotter for sailing and motor yachts
 long_description: |
@@ -44,7 +44,7 @@ routing:
   subdomain: avnav
   port: 8080  # Main web UI port (not the exposed 8083 AvnavOchartsPro port)
   auth:
-    mode: none
+    mode: forward_auth
 layout:
   priority: 50
   width: 2


### PR DESCRIPTION
## Summary

- Enable ForwardAuth for AvNav to require Authelia authentication
- Change `auth.mode` from `none` to `forward_auth`
- Bump version to 20251028-8

## Why

AvNav currently has no authentication - anyone on the network can access it. By enabling ForwardAuth, users must authenticate with Authelia before accessing AvNav, improving security.

## How it works

1. User visits avnav.halos.local
2. Traefik's ForwardAuth middleware checks with Authelia
3. If not logged in → redirect to Authelia login
4. After login → ForwardAuth allows access to AvNav

AvNav itself doesn't need any code changes - authentication is handled entirely at the proxy level by Traefik + Authelia.

## Test plan

- [ ] Visit https://avnav.halos.local without being logged in
- [ ] Verify redirect to auth.halos.local for login
- [ ] After login, verify access to AvNav is granted
- [ ] Verify AvNav functions normally after authentication

🤖 Generated with [Claude Code](https://claude.com/claude-code)