### PR TITLE
chore(ci): skip lintian in PR checks

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,3 +7,7 @@ on:
 jobs:
   checks:
     uses: hatlabs/shared-workflows/.github/workflows/pr-checks.yml@main
+    with:
+      # Skip lintian in PR checks - container-packaging-tools ensures compliance
+      # Lintian runs as a backstop in build-release.yml before publishing
+      skip-lintian: true


### PR DESCRIPTION
## Summary

- Skip redundant lintian checks in PR workflow
- container-packaging-tools ensures Debian package compliance
- Lintian now runs as a backstop in build-release.yml before publishing

## Dependencies

⚠️ **Merge after**: https://github.com/hatlabs/shared-workflows/pull/9

This PR depends on the `run-lintian` parameter being available in build-release.yml. Merge the shared-workflows PR first.

## Test plan

- [ ] Verify PR checks pass without running lintian
- [ ] Verify lintian still runs during release (after shared-workflows PR is merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)