### PR TITLE
Update Signal K Server to official OIDC release

### DIFF
--- a/apps/signalk-server/docker-compose.yml
+++ b/apps/signalk-server/docker-compose.yml
@@ -1,7 +1,7 @@
 
 services:
   signalk-server:
-    image: ghcr.io/hatlabs/signalk-server:v2.19.0-beta.4-oidc-fix
+    image: signalk/signalk-server:sha-90d6c6c-24.x
     container_name: signalk-server
     restart: unless-stopped
     logging:

--- a/apps/signalk-server/metadata.yaml
+++ b/apps/signalk-server/metadata.yaml
@@ -1,7 +1,7 @@
 name: Signal K Server
 app_id: signalk-server
-version: 2.19.0-beta.4-2
-upstream_version: 2.19.0-beta.4
+version: 2.19.2~1.90d6c6c-1
+upstream_version: 2.19.2~1.90d6c6c
 description: Signal K server for marine data processing and routing
 long_description: |
   Signal K is a modern and open data format for marine use. A Signal K server

--- a/tests/test_version_management.py
+++ b/tests/test_version_management.py
@@ -112,16 +112,21 @@ class TestAppVersionParsing:
             # Expected formats:
             # - Semver: X.Y.Z, X.Y.Z-N, or X.Y.Z-prerelease-N (e.g., 2.17.2-1, 2.19.0-beta.4-1)
             # - Date-based: YYYYMMDD-N (e.g., 20240520-1)
+            # - Pre-release with git SHA: X.Y.Z~N.sha-N (e.g., 2.19.2~1.90d6c6c-1)
             # Pre-release identifiers like alpha.N, beta.N, rc.N are allowed
             semver_pattern = r"^\d+\.\d+\.\d+(-[a-zA-Z]+\.\d+)?(-\d+)?$"
             date_pattern = r"^\d{8}-\d+$"
+            prerelease_pattern = r"^\d+\.\d+\.\d+~\d+\.[a-f0-9]+-\d+$"
 
-            is_valid = re.match(semver_pattern, version) or re.match(
-                date_pattern, version
+            is_valid = (
+                re.match(semver_pattern, version)
+                or re.match(date_pattern, version)
+                or re.match(prerelease_pattern, version)
             )
             assert is_valid, (
                 f"App {app_name} has invalid version format: {version} "
-                f"(expected semver like '2.17.2-1' or '2.19.0-beta.4-1', or date-based like '20240520-1')"
+                f"(expected semver like '2.17.2-1', '2.19.0-beta.4-1', "
+                f"pre-release like '2.19.2~1.90d6c6c-1', or date-based like '20240520-1')"
             )
 
 


### PR DESCRIPTION
## Summary

- Switch from test image to official Docker Hub release with merged OIDC support
- Image: `signalk/signalk-server:sha-90d6c6c-24.x`
- Version: 2.19.2+90d6c6c

## Test plan

- [ ] Deploy to test device and verify Signal K starts
- [ ] Test OIDC authentication flow with Authelia

🤖 Generated with [Claude Code](https://claude.com/claude-code)