### PR TITLE
feat(signalk-server): update to official v2.20.1 image

### DIFF
--- a/apps/signalk-server/docker-compose.yml
+++ b/apps/signalk-server/docker-compose.yml
@@ -1,7 +1,7 @@
 
 services:
   signalk-server:
-    image: ghcr.io/hatlabs/signalk-server:oidc-test
+    image: signalk/signalk-server:v2.20.1
     container_name: signalk-server
     restart: unless-stopped
     logging:

--- a/apps/signalk-server/metadata.yaml
+++ b/apps/signalk-server/metadata.yaml
@@ -1,7 +1,7 @@
 name: Signal K Server
 app_id: signalk-server
-version: 2.19.2~1.90d6c6c-2
-upstream_version: 2.19.2~1.90d6c6c
+version: 2.20.1-1
+upstream_version: 2.20.1
 description: Signal K server for marine data processing and routing
 long_description: |
   Signal K is a modern and open data format for marine use. A Signal K server


### PR DESCRIPTION
## Summary

- Switch from custom OIDC fork to official Signal K v2.20.1
- Update version to 2.20.1-1

## Changes

- **Image**: `ghcr.io/hatlabs/signalk-server:oidc-test` → `signalk/signalk-server:v2.20.1`
- **Version**: `2.19.2~1.90d6c6c-2` → `2.20.1-1`

## Benefits

- No longer need to maintain a custom fork/image
- Benefit from upstream security fixes automatically
- v2.20.1 includes: improved logging, mobile DataBrowser layout fix, mDNS improvements

## Dependencies

⚠️ **Merge #110 first** - the reverse proxy settings fix is required for OIDC to work correctly.

Closes #109

## Test plan

- [ ] Pull new image and restart Signal K
- [ ] Verify OIDC authentication flow works (after #110 is merged)
- [ ] Run `./tools/test-oidc-all.sh` to validate SSO integration
- [ ] Confirm Signal K starts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)