### PR TITLE
Add dbus volume mount to avnav for avahi functionality

### DIFF
--- a/apps/avnav/docker-compose.yml
+++ b/apps/avnav/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     volumes:
       - ${CONTAINER_DATA_ROOT}/data:/var/lib/avnav
       - /dev:/dev
+      - /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket
     environment:
       - UID=1000
       - GID=1000

--- a/apps/avnav/metadata.yaml
+++ b/apps/avnav/metadata.yaml
@@ -1,6 +1,6 @@
 name: AvNav
 app_id: avnav
-version: 20251028-8
+version: 20251028-9
 upstream_version: "20251028"
 description: Touch-optimized chart plotter for sailing and motor yachts
 long_description: |


### PR DESCRIPTION
## Summary

- Adds `/var/run/dbus/` volume mount to the avnav container to enable avahi/dbus communication and eliminate avahi error messages

Closes #65

## Test plan

- [ ] Install updated avnav package
- [ ] Verify avnav container starts without avahi error messages in logs
- [ ] Verify avahi/mDNS functionality works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)