### PR TITLE
Prioritize docker.io over docker-ce in dependencies

### DIFF
--- a/apps/avnav/metadata.yaml
+++ b/apps/avnav/metadata.yaml
@@ -33,7 +33,7 @@ tags:
 debian_section: graphics
 architecture: all
 depends:
-  - docker-ce (>= 20.10) | docker.io (>= 20.10)
+  - docker.io (>= 20.10) | docker-ce (>= 20.10)
 web_ui:
   enabled: true
   path: /

--- a/apps/grafana/metadata.yaml
+++ b/apps/grafana/metadata.yaml
@@ -28,7 +28,7 @@ tags:
 debian_section: web
 architecture: all
 depends:
-  - docker-ce (>= 20.10) | docker.io (>= 20.10)
+  - docker.io (>= 20.10) | docker-ce (>= 20.10)
 recommends:
   - marine-influxdb-container
 web_ui:

--- a/apps/influxdb/metadata.yaml
+++ b/apps/influxdb/metadata.yaml
@@ -27,7 +27,7 @@ tags:
 debian_section: net
 architecture: all
 depends:
-  - docker-ce (>= 20.10) | docker.io (>= 20.10)
+  - docker.io (>= 20.10) | docker-ce (>= 20.10)
 web_ui:
   enabled: true
   path: /

--- a/apps/opencpn/metadata.yaml
+++ b/apps/opencpn/metadata.yaml
@@ -32,7 +32,7 @@ tags:
 debian_section: graphics
 architecture: all
 depends:
-  - docker-ce (>= 20.10) | docker.io (>= 20.10)
+  - docker.io (>= 20.10) | docker-ce (>= 20.10)
 web_ui:
   enabled: true
   path: /

--- a/apps/signalk-server/metadata.yaml
+++ b/apps/signalk-server/metadata.yaml
@@ -28,7 +28,7 @@ tags:
 debian_section: net
 architecture: all
 depends:
-  - docker-ce (>= 20.10) | docker.io (>= 20.10)
+  - docker.io (>= 20.10) | docker-ce (>= 20.10)
   - python3-bcrypt
 web_ui:
   enabled: true

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -2,7 +2,7 @@
 
 **Status**: Draft
 **Date**: 2025-11-11
-**Last Updated**: 2025-11-11
+**Last Updated**: 2026-01-28
 
 ## Overview
 
@@ -175,7 +175,7 @@ Required metadata describing the application:
   "debian_section": "net",
   "architecture": "arm64",
   "depends": [
-    "docker-ce (>= 20.10) | docker.io (>= 20.10)"
+    "docker.io (>= 20.10) | docker-ce (>= 20.10)"
   ],
   "web_ui": {
     "enabled": true,
@@ -464,7 +464,7 @@ The `.github/workflows/build.yml` workflow:
 All container app packages directly depend on Docker:
 
 ```
-Depends: docker-ce (>= 20.10) | docker.io (>= 20.10)
+Depends: docker.io (>= 20.10) | docker-ce (>= 20.10)
 ```
 
 This can be refined later with:


### PR DESCRIPTION
## Summary
- Change dependency order from `docker-ce | docker.io` to `docker.io | docker-ce`
- Updates 5 app metadata files: avnav, grafana, influxdb, opencpn, signalk-server
- Updates docs/DESIGN.md examples

Part of docker.io migration: hatlabs/halos-pi-gen#22

## Test plan
- [ ] CI builds packages successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)