### PR TITLE
Rebuild marine app packages with display name debtags

### DIFF
--- a/apps/avnav/metadata.yaml
+++ b/apps/avnav/metadata.yaml
@@ -1,6 +1,6 @@
 name: AvNav
 app_id: avnav
-version: 20251028-9
+version: 20251028-10
 upstream_version: "20251028"
 description: Touch-optimized chart plotter for sailing and motor yachts
 long_description: |

--- a/apps/grafana/metadata.yaml
+++ b/apps/grafana/metadata.yaml
@@ -1,6 +1,6 @@
 name: Grafana
 app_id: grafana
-version: 12.1.4-17
+version: 12.1.4-18
 upstream_version: 12.1.4
 description: Data visualization and monitoring platform
 long_description: |

--- a/apps/influxdb/metadata.yaml
+++ b/apps/influxdb/metadata.yaml
@@ -1,6 +1,6 @@
 name: InfluxDB
 app_id: influxdb
-version: 2.7.12-8
+version: 2.7.12-9
 upstream_version: 2.7.12
 description: Time-series database for marine data logging
 long_description: |

--- a/apps/opencpn/metadata.yaml
+++ b/apps/opencpn/metadata.yaml
@@ -1,6 +1,6 @@
 name: OpenCPN
 app_id: opencpn
-version: 5.12.4-7
+version: 5.12.4-8
 upstream_version: 5.12.4
 description: Open source chart plotter and navigation software
 long_description: |

--- a/apps/signalk-server/metadata.yaml
+++ b/apps/signalk-server/metadata.yaml
@@ -1,6 +1,6 @@
 name: Signal K Server
 app_id: signalk-server
-version: 2.20.0-1
+version: 2.20.0-2
 upstream_version: 2.20.0
 description: Signal K server for marine data processing and routing
 long_description: |


### PR DESCRIPTION
## Summary

- Bump all marine app package versions to trigger rebuilds with `container-packaging-tools` which now emits `x-display-name` debtags
- `cockpit-container-apps` reads these debtags to show friendly app names in the UI, but existing packages were built before this support was added

## Test plan

- [ ] Verify CI builds all five packages successfully
- [ ] Install updated packages on test device and confirm `apt-cache show <package>` includes `x-display-name::` in the Tag field
- [ ] Verify cockpit-container-apps displays friendly names (e.g., "Signal K Server" instead of "marine-signalk-server-container")

🤖 Generated with [Claude Code](https://claude.com/claude-code)