### PR TITLE
Update Signal K Server to 2.20.2

### DIFF
--- a/apps/signalk-server/docker-compose.yml
+++ b/apps/signalk-server/docker-compose.yml
@@ -1,7 +1,7 @@
 
 services:
   signalk-server:
-    image: signalk/signalk-server:v2.20.0
+    image: signalk/signalk-server:v2.20.2
     container_name: signalk-server
     restart: unless-stopped
     logging:

--- a/apps/signalk-server/metadata.yaml
+++ b/apps/signalk-server/metadata.yaml
@@ -1,7 +1,7 @@
 name: Signal K Server
 app_id: signalk-server
-version: 2.20.0-2
-upstream_version: 2.20.0
+version: 2.20.2-1
+upstream_version: 2.20.2
 description: Signal K server for marine data processing and routing
 long_description: |
   Signal K is a modern and open data format for marine use. A Signal K server


### PR DESCRIPTION
## Summary

- Update Signal K Server Docker image from v2.20.0 to v2.20.2
- Bump package version to 2.20.2-1

## Test plan

- [ ] Verify CI builds the package successfully
- [ ] Install on test device and confirm Signal K Server starts with the new image
- [ ] Verify Signal K web UI is accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)