### PR TITLE
Update Grafana to 12.3.2

### DIFF
--- a/apps/grafana/docker-compose.yml
+++ b/apps/grafana/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   grafana:
-    image: grafana/grafana:12.1.4
+    image: grafana/grafana:12.3.2
     container_name: grafana
     user: "472"
     restart: unless-stopped

--- a/apps/grafana/metadata.yaml
+++ b/apps/grafana/metadata.yaml
@@ -1,7 +1,7 @@
 name: Grafana
 app_id: grafana
-version: 12.1.4-18
-upstream_version: 12.1.4
+version: 12.3.2-1
+upstream_version: 12.3.2
 description: Data visualization and monitoring platform
 long_description: |
   Grafana is an open-source platform for monitoring and observability. Create


### PR DESCRIPTION
## Summary

- Update Grafana Docker image from 12.1.4 to 12.3.2
- Bump package version to 12.3.2-1

## Test plan

- [ ] Verify CI builds the package successfully
- [ ] Install on test device and confirm Grafana starts with the new image
- [ ] Verify Grafana web UI and OIDC login work

🤖 Generated with [Claude Code](https://claude.com/claude-code)