### PR TITLE
Update InfluxDB to 2.8.0

### DIFF
--- a/apps/influxdb/docker-compose.yml
+++ b/apps/influxdb/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   influxdb:
-    image: influxdb:2.7.12
+    image: influxdb:2.8.0
     container_name: influxdb
     restart: unless-stopped
     logging:

--- a/apps/influxdb/metadata.yaml
+++ b/apps/influxdb/metadata.yaml
@@ -1,7 +1,7 @@
 name: InfluxDB
 app_id: influxdb
-version: 2.7.12-9
-upstream_version: 2.7.12
+version: 2.8.0-1
+upstream_version: 2.8.0
 description: Time-series database for marine data logging
 long_description: |
   InfluxDB is a high-performance time-series database designed for handling


### PR DESCRIPTION
## Summary

- Update InfluxDB Docker image from 2.7.12 to 2.8.0 (minor version bump)
- Bump package version to 2.8.0-1

## Test plan

- [ ] Verify CI builds the package successfully
- [ ] Install on test device and confirm InfluxDB starts with the new image
- [ ] Verify existing data is accessible after upgrade
- [ ] Verify Grafana can still query InfluxDB

🤖 Generated with [Claude Code](https://claude.com/claude-code)