### PR TITLE
Advertise reverse proxy URL via Signal K mDNS

### DIFF
--- a/apps/signalk-server/docker-compose.yml
+++ b/apps/signalk-server/docker-compose.yml
@@ -14,6 +14,8 @@ services:
       - "${HALOS_DOMAIN}:127.0.0.1"
       - "signalk.${HALOS_DOMAIN}:127.0.0.1"
     environment:
+      - EXTERNALHOST=${EXTERNALHOST:-}
+      - EXTERNALPORT=${EXTERNALPORT:-}
       - NODE_NO_WARNINGS=1
       - NODE_TLS_REJECT_UNAUTHORIZED=0
       - SIGNALK_OIDC_ENABLED=${SIGNALK_OIDC_ENABLED:-false}

--- a/apps/signalk-server/metadata.yaml
+++ b/apps/signalk-server/metadata.yaml
@@ -1,6 +1,6 @@
 name: Signal K Server
 app_id: signalk-server
-version: 2.21.2-1
+version: 2.21.2-2
 upstream_version: 2.21.2
 description: Signal K server for marine data processing and routing
 long_description: |

--- a/apps/signalk-server/prestart.sh
+++ b/apps/signalk-server/prestart.sh
@@ -73,6 +73,8 @@ RUNTIME_ENV_DIR="/run/container-apps/marine-signalk-server-container"
 mkdir -p "${RUNTIME_ENV_DIR}"
 cat > "${RUNTIME_ENV_DIR}/runtime.env" << EOF
 HALOS_DOMAIN=${HALOS_DOMAIN}
+EXTERNALHOST=signalk.${HALOS_DOMAIN}
+EXTERNALPORT=443
 SIGNALK_OIDC_CLIENT_SECRET=$(cat "${OIDC_SECRET_FILE}")
 SIGNALK_OIDC_ISSUER=https://auth.${HALOS_DOMAIN}
 SIGNALK_OIDC_REDIRECT_URI=https://signalk.${HALOS_DOMAIN}/signalk/v1/auth/oidc/callback


### PR DESCRIPTION
## Summary

- Configure Signal K's built-in mDNS to advertise `signalk.<hostname>.local:443` (the Traefik reverse proxy URL) instead of `<hostname>:3000` (the direct container port)
- Uses Signal K's `EXTERNALHOST` and `EXTERNALPORT` environment variables, which take highest priority in hostname/port resolution

## Test plan

- [ ] Deploy updated package to test device
- [ ] Verify `avahi-browse -arpt | grep signalk` shows `signalk.<hostname>.local` as the advertised host
- [ ] Verify Signal K HTTP and WebSocket services advertise port 443
- [ ] Verify Signal K web UI is still accessible via `https://signalk.<hostname>.local/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)