### PR TITLE
Bump signalk-server version to 2.20.2-3

### DIFF
--- a/apps/signalk-server/metadata.yaml
+++ b/apps/signalk-server/metadata.yaml
@@ -1,6 +1,6 @@
 name: Signal K Server
 app_id: signalk-server
-version: 2.20.2-2
+version: 2.20.2-3
 upstream_version: 2.20.2
 description: Signal K server for marine data processing and routing
 long_description: |


### PR DESCRIPTION
## Summary

Bump signalk-server package version to trigger rebuild with gpsd provider configuration.

## Test plan

- [ ] Verify package builds successfully
- [ ] Verify new package version is published

🤖 Generated with [Claude Code](https://claude.com/claude-code)