### PR TITLE
feat: add daily container image update checker

### DIFF
--- a/.github/workflows/check-updates.yml
+++ b/.github/workflows/check-updates.yml
@@ -1,0 +1,19 @@
+name: Check Container Image Updates
+
+on:
+  schedule:
+    - cron: '0 6 * * *'  # Daily 06:00 UTC
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.repository }}-check-image-updates
+  cancel-in-progress: true
+
+jobs:
+  check-updates:
+    uses: hatlabs/shared-workflows/.github/workflows/check-image-updates.yml@main
+    with:
+      compose-pattern: 'apps/*/docker-compose.yml'
+    permissions:
+      contents: write
+      pull-requests: write


### PR DESCRIPTION
## Summary

- Adds a daily workflow (06:00 UTC) that checks all marine app container images for updates
- Uses the shared `check-image-updates.yml` workflow with pattern `apps/*/docker-compose.yml`
- When updates are found, creates a PR with updated compose files and per-app metadata.yaml version bumps

**Depends on**: hatlabs/shared-workflows#15 (must be merged first)

## Test plan

- [ ] Merge shared-workflows PR first
- [ ] Trigger via `workflow_dispatch` on this repo
- [ ] Verify all 5 app images are detected and registries queried
- [ ] If updates exist: verify PR has correct metadata.yaml bumps and CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)