### PR TITLE
Mount halpid socket in Signal K server container

### DIFF
--- a/apps/signalk-server/docker-compose.yml
+++ b/apps/signalk-server/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       - ${CONTAINER_DATA_ROOT}/data:/home/node/.signalk
       - /dev:/dev
       - /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket
+      - /run/halpid/halpid.sock:/run/halpid/halpid.sock
     privileged: true
     security_opt:
       - no-new-privileges:false

--- a/apps/signalk-server/metadata.yaml
+++ b/apps/signalk-server/metadata.yaml
@@ -1,6 +1,6 @@
 name: Signal K Server
 app_id: signalk-server
-version: 2.22.0-1
+version: 2.22.0-2
 upstream_version: 2.22.0
 description: Signal K server for marine data processing and routing
 long_description: |


### PR DESCRIPTION
## Summary

- Mount `/run/halpid/halpid.sock` into the Signal K server container to allow the signalk-halpi-plugin to communicate with the halpid daemon via its REST API

## Test plan

- [ ] Verify Signal K server container starts with the new mount
- [ ] Confirm signalk-halpi-plugin can reach halpid via the socket

🤖 Generated with [Claude Code](https://claude.com/claude-code)