### PR TITLE
Mount host /run in Signal K server container

### DIFF
--- a/apps/signalk-server/docker-compose.yml
+++ b/apps/signalk-server/docker-compose.yml
@@ -32,8 +32,7 @@ services:
     volumes:
       - ${CONTAINER_DATA_ROOT}/data:/home/node/.signalk
       - /dev:/dev
-      - /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket
-      - /run/halpid/halpid.sock:/run/halpid/halpid.sock
+      - /run:/run
     privileged: true
     security_opt:
       - no-new-privileges:false

--- a/apps/signalk-server/metadata.yaml
+++ b/apps/signalk-server/metadata.yaml
@@ -1,6 +1,6 @@
 name: Signal K Server
 app_id: signalk-server
-version: 2.22.0-2
+version: 2.22.0-3
 upstream_version: 2.22.0
 description: Signal K server for marine data processing and routing
 long_description: |


### PR DESCRIPTION
## Summary

- Replace individual socket mounts (D-Bus, halpid) with a single `/run:/run` mount
- Gives SK plugins access to any host daemon socket without variant-specific overrides
- Subsumes the `/var/run/dbus/system_bus_socket` mount (`/var/run` → `/run` symlink on Debian)

Supersedes #130 which mounted only the halpid socket, causing issues on non-HALPI2 variants where the socket doesn't exist.

## Test plan

- [ ] Verify Signal K server starts correctly with `/run` mount
- [ ] Confirm D-Bus access still works (was previously mounted individually)
- [ ] Confirm signalk-halpi-plugin can reach halpid via `/run/halpid/halpid.sock`

🤖 Generated with [Claude Code](https://claude.com/claude-code)