### PR TITLE
chore: update maintainer from Hat Labs to Matti Airas

### DIFF
--- a/apps/avnav/metadata.yaml
+++ b/apps/avnav/metadata.yaml
@@ -17,7 +17,7 @@ long_description: |
   - NMEA data display and logging
   - Plugin system for extensions
 homepage: https://www.wellenvogel.net/software/avnav/docs/beschreibung.html
-maintainer: Hat Labs <support@hatlabs.fi>
+maintainer: Matti Airas <matti.airas@hatlabs.fi>
 license: GPL-3.0
 tags:
   - role::container-app

--- a/apps/grafana/metadata.yaml
+++ b/apps/grafana/metadata.yaml
@@ -15,7 +15,7 @@ long_description: |
   - Dashboard sharing and templating
   - Plugin ecosystem
 homepage: https://grafana.com/
-maintainer: Hat Labs <support@hatlabs.fi>
+maintainer: Matti Airas <matti.airas@hatlabs.fi>
 license: AGPL-3.0
 tags:
   - role::container-app

--- a/apps/influxdb/metadata.yaml
+++ b/apps/influxdb/metadata.yaml
@@ -15,7 +15,7 @@ long_description: |
   - Retention policies for automatic data management
   - Integration with Grafana for visualization
 homepage: https://www.influxdata.com/
-maintainer: Hat Labs <support@hatlabs.fi>
+maintainer: Matti Airas <matti.airas@hatlabs.fi>
 license: MIT
 tags:
   - role::container-app

--- a/apps/opencpn/metadata.yaml
+++ b/apps/opencpn/metadata.yaml
@@ -16,7 +16,7 @@ long_description: |
   - Extensive plugin system
   - Route and waypoint management
 homepage: https://opencpn.org/
-maintainer: Hat Labs <support@hatlabs.fi>
+maintainer: Matti Airas <matti.airas@hatlabs.fi>
 license: GPL-2.0
 tags:
   - role::container-app

--- a/apps/signalk-server/metadata.yaml
+++ b/apps/signalk-server/metadata.yaml
@@ -15,7 +15,7 @@ long_description: |
   - Plugin system for extending functionality
   - Instrument integration and display
 homepage: https://signalk.org/
-maintainer: Hat Labs <support@hatlabs.fi>
+maintainer: Matti Airas <matti.airas@hatlabs.fi>
 license: Apache-2.0
 tags:
   - role::container-app

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -163,7 +163,7 @@ Required metadata describing the application:
     "screenshot1.png",
     "screenshot2.png"
   ],
-  "maintainer": "Hat Labs <support@hatlabs.fi>",
+  "maintainer": "Matti Airas <matti.airas@hatlabs.fi>",
   "license": "Apache-2.0",
   "tags": [
     "role::container-app",

--- a/run
+++ b/run
@@ -168,7 +168,7 @@ marine-container-store (${new_version}-1) stable; urgency=medium
 
   * Version bump to ${new_version}
 
- -- Hat Labs <info@hatlabs.fi>  $(LC_ALL=C date '+%a, %d %b %Y %H:%M:%S %z')
+ -- Matti Airas <matti.airas@hatlabs.fi>  $(LC_ALL=C date '+%a, %d %b %Y %H:%M:%S %z')
 
 CHANGELOG
   cat store/debian/changelog >> "$temp_file"

--- a/store/debian/control
+++ b/store/debian/control
@@ -1,7 +1,7 @@
 Source: marine-container-store
 Section: admin
 Priority: optional
-Maintainer: Hat Labs <info@hatlabs.fi>
+Maintainer: Matti Airas <matti.airas@hatlabs.fi>
 Build-Depends: debhelper-compat (= 13)
 Standards-Version: 4.6.0
 Homepage: https://github.com/halos-org/halos-marine-containers

--- a/store/debian/copyright
+++ b/store/debian/copyright
@@ -1,6 +1,6 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: marine-container-store
-Upstream-Contact: Hat Labs <info@hatlabs.fi>
+Upstream-Contact: Matti Airas <matti.airas@hatlabs.fi>
 Source: https://github.com/halos-org/halos-marine-containers
 
 Files: *


### PR DESCRIPTION
## Summary
- Update package maintainer/author from "Hat Labs <info@hatlabs.fi>" and "Hat Labs <support@hatlabs.fi>" to "Matti Airas <matti.airas@hatlabs.fi>" across metadata, debian packaging, and changelog generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)