### PR TITLE
Add init: true to all marine app services for graceful shutdown

### DIFF
--- a/apps/avnav/docker-compose.yml
+++ b/apps/avnav/docker-compose.yml
@@ -2,6 +2,7 @@ services:
   avnav:
     image: xfreex/avnav-stable:20251028
     container_name: avnav
+    init: true
     restart: unless-stopped
     logging:
       driver: journald

--- a/apps/avnav/metadata.yaml
+++ b/apps/avnav/metadata.yaml
@@ -1,6 +1,6 @@
 name: AvNav
 app_id: avnav
-version: 20251028-11
+version: 20251028-12
 upstream_version: "20251028"
 description: Touch-optimized chart plotter for sailing and motor yachts
 long_description: |

--- a/apps/grafana/docker-compose.yml
+++ b/apps/grafana/docker-compose.yml
@@ -2,6 +2,7 @@ services:
   grafana:
     image: grafana/grafana:12.3.3
     container_name: grafana
+    init: true
     user: "472"
     restart: unless-stopped
     extra_hosts:

--- a/apps/grafana/metadata.yaml
+++ b/apps/grafana/metadata.yaml
@@ -1,6 +1,6 @@
 name: Grafana
 app_id: grafana
-version: 12.3.3-1
+version: 12.3.3-2
 upstream_version: 12.3.3
 description: Data visualization and monitoring platform
 long_description: |

--- a/apps/influxdb/docker-compose.yml
+++ b/apps/influxdb/docker-compose.yml
@@ -2,6 +2,7 @@ services:
   influxdb:
     image: influxdb:2.8.0
     container_name: influxdb
+    init: true
     restart: unless-stopped
     logging:
       driver: journald

--- a/apps/influxdb/metadata.yaml
+++ b/apps/influxdb/metadata.yaml
@@ -1,6 +1,6 @@
 name: InfluxDB
 app_id: influxdb
-version: 2.8.0-1
+version: 2.8.0-2
 upstream_version: 2.8.0
 description: Time-series database for marine data logging
 long_description: |

--- a/apps/opencpn/docker-compose.yml
+++ b/apps/opencpn/docker-compose.yml
@@ -2,6 +2,7 @@ services:
   opencpn:
     image: ghcr.io/halos-org/opencpn-docker:5.12.4
     container_name: opencpn
+    init: true
     restart: unless-stopped
     logging:
       driver: journald

--- a/apps/opencpn/metadata.yaml
+++ b/apps/opencpn/metadata.yaml
@@ -1,6 +1,6 @@
 name: OpenCPN
 app_id: opencpn
-version: 5.12.4-9
+version: 5.12.4-10
 upstream_version: 5.12.4
 description: Open source chart plotter and navigation software
 long_description: |

--- a/apps/signalk-server/docker-compose.yml
+++ b/apps/signalk-server/docker-compose.yml
@@ -3,6 +3,7 @@ services:
   signalk-server:
     image: signalk/signalk-server:v2.22.1
     container_name: signalk-server
+    init: true
     restart: unless-stopped
     logging:
       driver: journald

--- a/apps/signalk-server/metadata.yaml
+++ b/apps/signalk-server/metadata.yaml
@@ -1,6 +1,6 @@
 name: Signal K Server
 app_id: signalk-server
-version: 2.22.1-1
+version: 2.22.1-2
 upstream_version: 2.22.1
 description: Signal K server for marine data processing and routing
 long_description: |


### PR DESCRIPTION
## Summary

- Add `init: true` to all 5 marine app compose files (signalk-server, avnav, influxdb, grafana, opencpn)
- Bump metadata.yaml versions for all apps

Containers using shell scripts as PID 1 (signalk-server, avnav) ignore SIGTERM and only stop after Docker's 10-second SIGKILL timeout. Adding init: true (tini) ensures proper signal forwarding.

## Test plan

- [ ] Deploy updated packages to halos.local
- [ ] Verify all marine containers stop in <500ms (was ~10s for signalk-server and avnav)
- [ ] Verify all marine containers start and function correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)