### PR TITLE
Remove user-configurable HTTP port from Signal K

### DIFF
--- a/apps/signalk-server/config.yml
+++ b/apps/signalk-server/config.yml
@@ -1,15 +1,3 @@
 version: "1.0"
 
-groups:
-  - id: network
-    label: Network Settings
-    description: Port and network configuration
-    fields:
-      - id: SIGNALK_PORT
-        label: HTTP Port
-        type: integer
-        default: 3000
-        min: 1024
-        max: 65535
-        required: true
-        description: Port for web interface and API
+groups: []

--- a/apps/signalk-server/metadata.yaml
+++ b/apps/signalk-server/metadata.yaml
@@ -1,6 +1,6 @@
 name: Signal K Server
 app_id: signalk-server
-version: 2.22.1-2
+version: 2.22.1-3
 upstream_version: 2.22.1
 description: Signal K server for marine data processing and routing
 long_description: |
@@ -48,7 +48,6 @@ routing:
     mode: none
   host_port: 3000
 default_config:
-  SIGNALK_PORT: "3000"
   # OIDC Configuration - enabled by default for SSO integration
   SIGNALK_OIDC_ENABLED: "true"
   SIGNALK_OIDC_ISSUER: "https://auth.${HALOS_DOMAIN}"


### PR DESCRIPTION
## Summary

- Remove the SIGNALK_PORT field from the Signal K config UI and default_config
- The port (3000) is baked into Traefik routing labels at build time via `routing.host_port`, so changing it via config would break reverse proxying

## Test plan

- [ ] Verify Signal K still starts and is accessible via `signalk.${HALOS_DOMAIN}`
- [ ] Verify the port configuration field no longer appears in the app settings UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)