### PR TITLE
Tag OpenCPN as experimental

### DIFF
--- a/apps/opencpn/metadata.yaml
+++ b/apps/opencpn/metadata.yaml
@@ -1,6 +1,6 @@
 name: OpenCPN
 app_id: opencpn
-version: 5.12.4-10
+version: 5.12.4-11
 upstream_version: 5.12.4
 description: Open source chart plotter and navigation software
 long_description: |
@@ -29,6 +29,7 @@ tags:
   - interface::web
   - use::routing
   - works-with::maps
+  - status::experimental
 debian_section: graphics
 architecture: all
 depends:


### PR DESCRIPTION
## Summary
- Add `status::experimental` debtag to OpenCPN's metadata to indicate its container packaging is experimental
- Bump version from 5.12.4-10 to 5.12.4-11

The tag is inert metadata until cockpit-container-apps gains UI support for status badges (halos-org/cockpit-container-apps PR forthcoming).

## Test plan
- [ ] CI passes (tag is a plain string, no schema restrictions)
- [ ] After deploy, verify the generated Debian control file includes the new tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)