### PR TITLE
Load Signal K provider snippets from drop-in directory

### DIFF
--- a/apps/signalk-server/metadata.yaml
+++ b/apps/signalk-server/metadata.yaml
@@ -1,6 +1,6 @@
 name: Signal K Server
 app_id: signalk-server
-version: 2.22.1-3
+version: 2.22.1-4
 upstream_version: 2.22.1
 description: Signal K server for marine data processing and routing
 long_description: |

--- a/apps/signalk-server/prestart.sh
+++ b/apps/signalk-server/prestart.sh
@@ -105,38 +105,54 @@ EOF
     echo "NOTE: Restart Authelia to pick up the new OIDC client"
 fi
 
-# Create settings.json with reverse proxy settings and gpsd provider if it doesn't exist
+# Create settings.json with reverse proxy settings and providers if it doesn't exist
 # Signal K runs behind Traefik, so we need ssl=false and trustProxy=true
-# gpsd provider connects to the system gpsd daemon for GPS data
+# The gpsd provider is always included; additional providers are loaded from
+# /etc/halos/signalk-providers.d/*.json (e.g., HALPI2 RS-485 on ttyAMA4)
 SETTINGS_FILE="${SIGNALK_DATA}/settings.json"
+PROVIDERS_DIR="/etc/halos/signalk-providers.d"
 if [ ! -f "${SETTINGS_FILE}" ]; then
-    echo "Creating settings.json with reverse proxy settings and gpsd provider..."
-    cat > "${SETTINGS_FILE}" << EOF
-{
-  "ssl": false,
-  "trustProxy": true,
-  "pipedProviders": [
-    {
-      "id": "gpsd",
-      "pipeElements": [
+    echo "Creating settings.json with reverse proxy settings and providers..."
+    python3 - "${SETTINGS_FILE}" "${PROVIDERS_DIR}" << 'PYEOF'
+import json, glob, sys, os
+
+settings_file = sys.argv[1]
+providers_dir = sys.argv[2]
+
+gpsd_provider = {
+    "id": "gpsd",
+    "pipeElements": [
         {
-          "type": "providers/gpsd",
-          "options": {
-            "hostname": "localhost",
-            "port": 2947,
-            "noDataReceivedTimeout": 30,
-            "reconnectInterval": 15
-          }
+            "type": "providers/gpsd",
+            "options": {
+                "hostname": "localhost",
+                "port": 2947,
+                "noDataReceivedTimeout": 30,
+                "reconnectInterval": 15,
+            },
         },
-        {
-          "type": "providers/nmea0183-signalk"
-        }
-      ],
-      "enabled": true
-    }
-  ]
+        {"type": "providers/nmea0183-signalk"},
+    ],
+    "enabled": True,
 }
-EOF
+
+providers = [gpsd_provider]
+
+if os.path.isdir(providers_dir):
+    for path in sorted(glob.glob(os.path.join(providers_dir, "*.json"))):
+        with open(path) as f:
+            providers.append(json.load(f))
+        print(f"  Added provider snippet: {path}")
+
+settings = {
+    "ssl": False,
+    "trustProxy": True,
+    "pipedProviders": providers,
+}
+
+with open(settings_file, "w") as f:
+    json.dump(settings, f, indent=2)
+PYEOF
     chown 1000:1000 "${SETTINGS_FILE}"
 fi
 


### PR DESCRIPTION
## Summary

- Replace static `settings.json` heredoc with a Python script that reads additional provider JSON snippets from `/etc/halos/signalk-providers.d/*.json`
- Enables hardware-specific stages (e.g., HALPI2 RS-485) to preconfigure Signal K connections at image build time
- When no snippets directory exists (non-HALPI2 images), behavior is identical to before

## Context

HALPI2 marine images have an RS-485 serial interface (`/dev/ttyAMA4`) that should come preconfigured in Signal K. This PR adds the infrastructure to support that — the actual RS-485 provider snippet will be added in a separate halos-pi-gen PR.

## Test plan

- [ ] Build a non-HALPI2 marine image → settings.json should contain only the gpsd provider (no regression)
- [ ] Build a HALPI2 marine image (after the halos-pi-gen companion PR) → settings.json should contain both gpsd and halpi2-rs485 providers
- [ ] Verify settings.json is only created on first boot (existing settings.json is not overwritten)

🤖 Generated with [Claude Code](https://claude.com/claude-code)