### PR TITLE
Ship default Signal K settings.json via default-data

### DIFF
--- a/apps/signalk-server/default-data/data/settings.json
+++ b/apps/signalk-server/default-data/data/settings.json
@@ -1,0 +1,24 @@
+{
+  "ssl": false,
+  "trustProxy": true,
+  "pipedProviders": [
+    {
+      "id": "gpsd",
+      "pipeElements": [
+        {
+          "type": "providers/gpsd",
+          "options": {
+            "hostname": "localhost",
+            "port": 2947,
+            "noDataReceivedTimeout": 30,
+            "reconnectInterval": 15
+          }
+        },
+        {
+          "type": "providers/nmea0183-signalk"
+        }
+      ],
+      "enabled": true
+    }
+  ]
+}

--- a/apps/signalk-server/metadata.yaml
+++ b/apps/signalk-server/metadata.yaml
@@ -1,6 +1,6 @@
 name: Signal K Server
 app_id: signalk-server
-version: 2.22.1-3
+version: 2.22.1-4
 upstream_version: 2.22.1
 description: Signal K server for marine data processing and routing
 long_description: |

--- a/apps/signalk-server/prestart.sh
+++ b/apps/signalk-server/prestart.sh
@@ -105,41 +105,7 @@ EOF
     echo "NOTE: Restart Authelia to pick up the new OIDC client"
 fi
 
-# Create settings.json with reverse proxy settings and gpsd provider if it doesn't exist
-# Signal K runs behind Traefik, so we need ssl=false and trustProxy=true
-# gpsd provider connects to the system gpsd daemon for GPS data
-SETTINGS_FILE="${SIGNALK_DATA}/settings.json"
-if [ ! -f "${SETTINGS_FILE}" ]; then
-    echo "Creating settings.json with reverse proxy settings and gpsd provider..."
-    cat > "${SETTINGS_FILE}" << EOF
-{
-  "ssl": false,
-  "trustProxy": true,
-  "pipedProviders": [
-    {
-      "id": "gpsd",
-      "pipeElements": [
-        {
-          "type": "providers/gpsd",
-          "options": {
-            "hostname": "localhost",
-            "port": 2947,
-            "noDataReceivedTimeout": 30,
-            "reconnectInterval": 15
-          }
-        },
-        {
-          "type": "providers/nmea0183-signalk"
-        }
-      ],
-      "enabled": true
-    }
-  ]
-}
-EOF
-    chown 1000:1000 "${SETTINGS_FILE}"
-fi
-
 # Ensure data directory is owned by node user (UID 1000)
+# settings.json is installed via default-data/ at package install time
 # The container runs as node:node, but prestart runs as root
 chown -R 1000:1000 "${CONTAINER_DATA_ROOT}"


### PR DESCRIPTION
## Summary

- Move Signal K `settings.json` (reverse proxy config + gpsd provider) from runtime generation in `prestart.sh` to a static `default-data/` file installed at package time
- Remove the settings.json heredoc block from prestart.sh

## Motivation

Build-time configuration is preferable to runtime assembly. With settings.json as a static file installed by the package, hardware-specific pi-gen stages can modify it at image build time — e.g., adding the HALPI2 RS-485 NMEA 0183 provider. A companion halos-pi-gen PR will follow.

## Test plan

- [ ] Fresh install: settings.json is created in the data volume by postinst with correct content and ownership (1000:1000)
- [ ] Existing install: settings.json is preserved (postinst only copies if file doesn't exist)
- [ ] Signal K starts correctly with the default-data settings.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)