### PR TITLE
Rebuild signalk-server with POSIX-compatible postinst

### DIFF
--- a/apps/signalk-server/metadata.yaml
+++ b/apps/signalk-server/metadata.yaml
@@ -1,6 +1,6 @@
 name: Signal K Server
 app_id: signalk-server
-version: 2.22.1-4
+version: 2.22.1-5
 upstream_version: 2.22.1
 description: Signal K server for marine data processing and routing
 long_description: |


### PR DESCRIPTION
## Summary

- Bump signalk-server revision to rebuild against container-packaging-tools 0.5.4, which fixes the bash-only `read -d ''` in the postinst default-data copy loop
- The previous postinst silently failed under dash (Debian's `/bin/sh`), preventing `settings.json` from being copied during pi-gen chroot builds

## Test plan

- [ ] CI builds successfully with the new container-packaging-tools
- [ ] pi-gen marine HALPI2 image build completes without `jq: error: Could not open file` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)