### PR TITLE
fix(opencpn): disable init to fix s6-overlay PID 1 conflict

### DIFF
--- a/apps/opencpn/docker-compose.yml
+++ b/apps/opencpn/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   opencpn:
     image: ghcr.io/halos-org/opencpn-docker:5.12.4
     container_name: opencpn
-    init: true
+    init: false  # s6-overlay must be PID 1; tini would break it
     restart: unless-stopped
     logging:
       driver: journald

--- a/apps/opencpn/metadata.yaml
+++ b/apps/opencpn/metadata.yaml
@@ -1,6 +1,6 @@
 name: OpenCPN
 app_id: opencpn
-version: 5.12.4-11
+version: 5.12.4-12
 upstream_version: 5.12.4
 description: Open source chart plotter and navigation software
 long_description: |


### PR DESCRIPTION
## Summary

- Explicitly sets `init: false` for OpenCPN to prevent `container-packaging-tools` from injecting tini as PID 1
- The linuxserver/selkies base image uses s6-overlay v3 which must be PID 1; tini at PID 1 causes startup failure with `s6-overlay-suexec: fatal: can only run as pid 1`
- Bumps app version to 5.12.4-12

## Test plan

- [ ] Install OpenCPN on halos.local and verify it starts without the s6-overlay error
- [ ] Verify the web UI is accessible via Traefik

🤖 Generated with [Claude Code](https://claude.com/claude-code)