### PR TITLE
Fix Signal K mDNS hostname double .local suffix

### DIFF
--- a/apps/signalk-server/metadata.yaml
+++ b/apps/signalk-server/metadata.yaml
@@ -1,6 +1,6 @@
 name: Signal K Server
 app_id: signalk-server
-version: 2.22.1-5
+version: 2.22.1-6
 upstream_version: 2.22.1
 description: Signal K server for marine data processing and routing
 long_description: |

--- a/apps/signalk-server/prestart.sh
+++ b/apps/signalk-server/prestart.sh
@@ -71,9 +71,10 @@ fi
 # OIDC settings expand HALOS_DOMAIN since systemd EnvironmentFile doesn't
 RUNTIME_ENV_DIR="/run/container-apps/marine-signalk-server-container"
 mkdir -p "${RUNTIME_ENV_DIR}"
+# EXTERNALHOST strips .local suffix — Signal K's mDNS library (dnssd) appends it
 cat > "${RUNTIME_ENV_DIR}/runtime.env" << EOF
 HALOS_DOMAIN=${HALOS_DOMAIN}
-EXTERNALHOST=signalk.${HALOS_DOMAIN}
+EXTERNALHOST=signalk.${HALOS_DOMAIN%.local}
 EXTERNALPORT=443
 SIGNALK_OIDC_CLIENT_SECRET=$(cat "${OIDC_SECRET_FILE}")
 SIGNALK_OIDC_ISSUER=https://auth.${HALOS_DOMAIN}


### PR DESCRIPTION
## Summary

- Fix `EXTERNALHOST` in Signal K prestart script to strip `.local` suffix before passing to the container
- Signal K's mDNS library (`dnssd`) appends `.local` automatically, so `signalk.halos.local` was being advertised as `signalk.halos.local.local`
- Uses bash parameter expansion (`${HALOS_DOMAIN%.local}`) to produce the correct `signalk.halos` hostname

## Context

Discovered while diagnosing a customer's mDNS hostname resolution issues. `avahi-browse -r _signalk-http._tcp` showed `hostname = [signalk.halos.local.local]`.

The `dnssd` library's `Advertisement` constructor sets `this._domain = 'local'` and constructs FQDNs as `misc.fqdn(this.hostname, this._domain)`, which joins them with `.`. So a hostname of `signalk.halos.local` becomes `signalk.halos.local.local.`.

## Test plan

- [ ] Deploy updated package to test device
- [ ] Restart `marine-signalk-server-container` service
- [ ] Verify `avahi-browse -r _signalk-http._tcp` shows `hostname = [signalk.halos.local]` (not `.local.local`)
- [ ] Verify Signal K web UI still accessible at `https://signalk.halos.local`

🤖 Generated with [Claude Code](https://claude.com/claude-code)