### PR TITLE
Update marine apps for port-based routing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,7 +212,7 @@ For testing that invalid authentication attempts are properly rejected (malforme
 
 ```bash
 # From the signalk-server directory
-./tools/test-auth-negative.sh -u https://signalk.myhostname.local -k -v
+./tools/test-auth-negative.sh -u https://myhostname.local/signalk-server -k -v
 
 # See signalk-server/tools/test-auth-negative.sh --help for options
 ```

--- a/apps/avnav/metadata.yaml
+++ b/apps/avnav/metadata.yaml
@@ -1,6 +1,6 @@
 name: AvNav
 app_id: avnav
-version: 20251028-12
+version: 20251028-13
 upstream_version: "20251028"
 description: Touch-optimized chart plotter for sailing and motor yachts
 long_description: |
@@ -41,7 +41,6 @@ web_ui:
   protocol: http
   visible: true
 routing:
-  subdomain: avnav
   port: 8080  # Main web UI port (not the exposed 8083 AvnavOchartsPro port)
   auth:
     mode: forward_auth

--- a/apps/grafana/docker-compose.yml
+++ b/apps/grafana/docker-compose.yml
@@ -6,11 +6,13 @@ services:
     user: "472"
     restart: unless-stopped
     extra_hosts:
-      # Allow Grafana to resolve auth subdomain for OIDC (mDNS doesn't work in containers)
-      - "auth.${HALOS_DOMAIN}:host-gateway"
+      # Allow Grafana to resolve HALOS_DOMAIN for OIDC (mDNS doesn't work in containers)
+      - "${HALOS_DOMAIN}:host-gateway"
     environment:
-      # Server URL for OAuth redirects
-      - GF_SERVER_ROOT_URL=https://grafana.${HALOS_DOMAIN}
+      # Server URL for OAuth redirects — uses port URL when available
+      - GF_SERVER_ROOT_URL=https://${HALOS_DOMAIN}:${HALOS_EXTERNAL_PORT:-443}
+      # Override OAuth redirect URI to use path redirect (survives 302 to port URL)
+      - GF_AUTH_GENERIC_OAUTH_REDIRECT_URL=https://${HALOS_DOMAIN}/grafana/login/generic_oauth
       # OAuth configuration for Authelia SSO
       - GF_AUTH_GENERIC_OAUTH_ENABLED=true
       - GF_AUTH_GENERIC_OAUTH_NAME=HaLOS SSO
@@ -18,9 +20,9 @@ services:
       - GF_AUTH_GENERIC_OAUTH_CLIENT_ID=grafana
       - GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET=${GRAFANA_OIDC_CLIENT_SECRET}
       - GF_AUTH_GENERIC_OAUTH_SCOPES=openid profile email groups
-      - GF_AUTH_GENERIC_OAUTH_AUTH_URL=https://auth.${HALOS_DOMAIN}/api/oidc/authorization
-      - GF_AUTH_GENERIC_OAUTH_TOKEN_URL=https://auth.${HALOS_DOMAIN}/api/oidc/token
-      - GF_AUTH_GENERIC_OAUTH_API_URL=https://auth.${HALOS_DOMAIN}/api/oidc/userinfo
+      - GF_AUTH_GENERIC_OAUTH_AUTH_URL=https://${HALOS_DOMAIN}/auth/api/oidc/authorization
+      - GF_AUTH_GENERIC_OAUTH_TOKEN_URL=https://${HALOS_DOMAIN}/auth/api/oidc/token
+      - GF_AUTH_GENERIC_OAUTH_API_URL=https://${HALOS_DOMAIN}/auth/api/oidc/userinfo
       - GF_AUTH_GENERIC_OAUTH_LOGIN_ATTRIBUTE_PATH=sub
       - GF_AUTH_GENERIC_OAUTH_EMAIL_ATTRIBUTE_PATH=email
       - GF_AUTH_GENERIC_OAUTH_GROUPS_ATTRIBUTE_PATH=groups
@@ -38,7 +40,7 @@ services:
       driver: journald
       options:
         tag: "{{.Name}}"
-    # No direct port exposure - access via Traefik at grafana.{hostname}.local
+    # No direct port exposure — access via Traefik on dedicated HTTPS port
     # halos-proxy-network is auto-injected by container-packaging-tools
     volumes:
       - ${CONTAINER_DATA_ROOT}/data:/var/lib/grafana

--- a/apps/grafana/metadata.yaml
+++ b/apps/grafana/metadata.yaml
@@ -1,6 +1,6 @@
 name: Grafana
 app_id: grafana
-version: 12.3.3-2
+version: 12.3.3-3
 upstream_version: 12.3.3
 description: Data visualization and monitoring platform
 long_description: |
@@ -38,7 +38,6 @@ web_ui:
   protocol: http
   visible: true
 routing:
-  subdomain: grafana
   auth:
     mode: none  # Grafana handles OAuth natively via prestart.sh OIDC registration
 layout:

--- a/apps/grafana/prestart.sh
+++ b/apps/grafana/prestart.sh
@@ -19,39 +19,44 @@ if [ ! -f "${OIDC_SECRET_FILE}" ]; then
     chmod 600 "${OIDC_SECRET_FILE}"
 fi
 
+# Read external port from port registry (assigned by configure-container-routing)
+EXTERNAL_PORT=""
+PORT_REGISTRY="/etc/halos/port-registry"
+if [ -f "${PORT_REGISTRY}" ]; then
+    EXTERNAL_PORT=$(grep "^grafana=" "${PORT_REGISTRY}" 2>/dev/null | cut -d= -f2)
+fi
+
 # Write runtime env file with expanded HALOS_DOMAIN
 RUNTIME_ENV_DIR="/run/container-apps/marine-grafana-container"
 mkdir -p "${RUNTIME_ENV_DIR}"
 cat > "${RUNTIME_ENV_DIR}/runtime.env" << EOF
 HALOS_DOMAIN=${HALOS_DOMAIN}
 GRAFANA_OIDC_CLIENT_SECRET=$(cat "${OIDC_SECRET_FILE}")
+HALOS_EXTERNAL_PORT=${EXTERNAL_PORT}
 EOF
 chmod 600 "${RUNTIME_ENV_DIR}/runtime.env"
 
 # Install OIDC client snippet for Authelia
+# Always written (not guarded) so redirect URIs stay current across upgrades
 OIDC_CLIENTS_DIR="/etc/halos/oidc-clients.d"
 OIDC_CLIENT_SNIPPET="${OIDC_CLIENTS_DIR}/grafana.yml"
-if [ ! -f "${OIDC_CLIENT_SNIPPET}" ]; then
-    echo "Installing OIDC client snippet for Authelia..."
-    mkdir -p "${OIDC_CLIENTS_DIR}"
-    cat > "${OIDC_CLIENT_SNIPPET}" << 'EOF'
+mkdir -p "${OIDC_CLIENTS_DIR}"
+cat > "${OIDC_CLIENT_SNIPPET}" << 'EOF'
 # Grafana OIDC Client Snippet
 # Installed by marine-grafana-container prestart.sh
 # Authelia's prestart script merges all snippets into oidc-clients.yml
+# Redirect URI uses path redirect (/grafana/) which 302s to the port URL
 
 client_id: grafana
 client_name: Grafana
 client_secret_file: /var/lib/container-apps/marine-grafana-container/data/oidc-secret
 redirect_uris:
-  - 'https://grafana.${HALOS_DOMAIN}/login/generic_oauth'
+  - 'https://${HALOS_DOMAIN}/grafana/login/generic_oauth'
 scopes: [openid, profile, email, groups]
 consent_mode: implicit
 token_endpoint_auth_method: client_secret_basic
 # Note: PKCE is enforced client-side via GF_AUTH_GENERIC_OAUTH_USE_PKCE=true
 EOF
-    echo "OIDC client snippet installed to ${OIDC_CLIENT_SNIPPET}"
-    echo "NOTE: Restart Authelia to pick up the new OIDC client"
-fi
 
 # Ensure data directory exists and has correct ownership (Grafana runs as UID 472)
 # Note: Only chown the data subdir, not the oidc-secret which should remain root-owned

--- a/apps/influxdb/metadata.yaml
+++ b/apps/influxdb/metadata.yaml
@@ -1,6 +1,6 @@
 name: InfluxDB
 app_id: influxdb
-version: 2.8.0-2
+version: 2.8.0-3
 upstream_version: 2.8.0
 description: Time-series database for marine data logging
 long_description: |
@@ -35,7 +35,6 @@ web_ui:
   protocol: http
   visible: true
 routing:
-  subdomain: influxdb
   auth:
     mode: none
 layout:

--- a/apps/opencpn/metadata.yaml
+++ b/apps/opencpn/metadata.yaml
@@ -1,6 +1,6 @@
 name: OpenCPN
 app_id: opencpn
-version: 5.12.4-12
+version: 5.12.4-13
 upstream_version: 5.12.4
 description: Open source chart plotter and navigation software
 long_description: |
@@ -41,7 +41,6 @@ web_ui:
   protocol: https
   visible: true
 routing:
-  subdomain: opencpn
   auth:
     mode: none
 layout:

--- a/apps/signalk-server/docker-compose.yml
+++ b/apps/signalk-server/docker-compose.yml
@@ -11,9 +11,8 @@ services:
         tag: "{{.Name}}"
     network_mode: host
     extra_hosts:
-      - "auth.${HALOS_DOMAIN}:127.0.0.1"
+      # Signal K uses host networking so resolves via host DNS/mDNS
       - "${HALOS_DOMAIN}:127.0.0.1"
-      - "signalk.${HALOS_DOMAIN}:127.0.0.1"
     environment:
       - EXTERNALHOST=${EXTERNALHOST:-}
       - EXTERNALPORT=${EXTERNALPORT:-}

--- a/apps/signalk-server/metadata.yaml
+++ b/apps/signalk-server/metadata.yaml
@@ -1,6 +1,6 @@
 name: Signal K Server
 app_id: signalk-server
-version: 2.22.1-6
+version: 2.22.1-7
 upstream_version: 2.22.1
 description: Signal K server for marine data processing and routing
 long_description: |
@@ -43,17 +43,16 @@ layout:
   x_offset: 0
   y_offset: 1
 routing:
-  subdomain: signalk
   auth:
     mode: none
   host_port: 3000
 default_config:
   # OIDC Configuration - enabled by default for SSO integration
   SIGNALK_OIDC_ENABLED: "true"
-  SIGNALK_OIDC_ISSUER: "https://auth.${HALOS_DOMAIN}"
+  SIGNALK_OIDC_ISSUER: "https://${HALOS_DOMAIN}/auth/"
   SIGNALK_OIDC_CLIENT_ID: "signalk"
   SIGNALK_OIDC_CLIENT_SECRET: ""
-  SIGNALK_OIDC_REDIRECT_URI: "https://signalk.${HALOS_DOMAIN}/signalk/v1/auth/oidc/callback"
+  SIGNALK_OIDC_REDIRECT_URI: "https://${HALOS_DOMAIN}/signalk-server/signalk/v1/auth/oidc/callback"
   SIGNALK_OIDC_SCOPE: "openid email profile groups"
   SIGNALK_OIDC_PROVIDER_NAME: "HaLOS SSO"
   SIGNALK_OIDC_DEFAULT_PERMISSION: "readonly"

--- a/apps/signalk-server/prestart.sh
+++ b/apps/signalk-server/prestart.sh
@@ -71,40 +71,45 @@ fi
 # OIDC settings expand HALOS_DOMAIN since systemd EnvironmentFile doesn't
 RUNTIME_ENV_DIR="/run/container-apps/marine-signalk-server-container"
 mkdir -p "${RUNTIME_ENV_DIR}"
+
+# Read external port from port registry (assigned by configure-container-routing)
+EXTERNAL_PORT=""
+PORT_REGISTRY="/etc/halos/port-registry"
+if [ -f "${PORT_REGISTRY}" ]; then
+    EXTERNAL_PORT=$(grep "^signalk-server=" "${PORT_REGISTRY}" 2>/dev/null | cut -d= -f2)
+fi
+
 # EXTERNALHOST strips .local suffix — Signal K's mDNS library (dnssd) appends it
 cat > "${RUNTIME_ENV_DIR}/runtime.env" << EOF
 HALOS_DOMAIN=${HALOS_DOMAIN}
-EXTERNALHOST=signalk.${HALOS_DOMAIN%.local}
-EXTERNALPORT=443
+EXTERNALHOST=${HALOS_DOMAIN%.local}
+EXTERNALPORT=${EXTERNAL_PORT:-443}
 SIGNALK_OIDC_CLIENT_SECRET=$(cat "${OIDC_SECRET_FILE}")
-SIGNALK_OIDC_ISSUER=https://auth.${HALOS_DOMAIN}
-SIGNALK_OIDC_REDIRECT_URI=https://signalk.${HALOS_DOMAIN}/signalk/v1/auth/oidc/callback
+SIGNALK_OIDC_ISSUER=https://${HALOS_DOMAIN}/auth/
+SIGNALK_OIDC_REDIRECT_URI=https://${HALOS_DOMAIN}/signalk-server/signalk/v1/auth/oidc/callback
 EOF
 chmod 600 "${RUNTIME_ENV_DIR}/runtime.env"
 
 # Install OIDC client snippet for Authelia
+# Always written (not guarded) so redirect URIs stay current across upgrades
 OIDC_CLIENTS_DIR="/etc/halos/oidc-clients.d"
 OIDC_CLIENT_SNIPPET="${OIDC_CLIENTS_DIR}/signalk.yml"
-if [ ! -f "${OIDC_CLIENT_SNIPPET}" ]; then
-    echo "Installing OIDC client snippet for Authelia..."
-    mkdir -p "${OIDC_CLIENTS_DIR}"
-    cat > "${OIDC_CLIENT_SNIPPET}" << 'EOF'
+mkdir -p "${OIDC_CLIENTS_DIR}"
+cat > "${OIDC_CLIENT_SNIPPET}" << 'EOF'
 # Signal K OIDC Client Snippet
 # Installed by marine-signalk-server-container prestart.sh
 # Authelia's prestart script merges all snippets into oidc-clients.yml
+# Redirect URI uses path redirect (/signalk-server/) which 302s to the port URL
 
 client_id: signalk
 client_name: Signal K Server
 client_secret_file: /var/lib/container-apps/marine-signalk-server-container/data/oidc-secret
 redirect_uris:
-  - 'https://signalk.${HALOS_DOMAIN}/signalk/v1/auth/oidc/callback'
+  - 'https://${HALOS_DOMAIN}/signalk-server/signalk/v1/auth/oidc/callback'
 scopes: [openid, profile, email, groups]
 consent_mode: implicit
 token_endpoint_auth_method: client_secret_post
 EOF
-    echo "OIDC client snippet installed to ${OIDC_CLIENT_SNIPPET}"
-    echo "NOTE: Restart Authelia to pick up the new OIDC client"
-fi
 
 # Ensure data directory is owned by node user (UID 1000)
 # settings.json is installed via default-data/ at package install time

--- a/tools/test-oidc-all.sh
+++ b/tools/test-oidc-all.sh
@@ -65,9 +65,9 @@ if [[ -z "$DOMAIN" ]]; then
     exit 1
 fi
 
-# URLs
-SK_URL="https://signalk.${DOMAIN}"
-AUTH_URL="https://auth.${DOMAIN}"
+# URLs (port-based routing uses path prefixes)
+SK_URL="https://${DOMAIN}/signalk-server"
+AUTH_URL="https://${DOMAIN}/auth"
 
 CURL_OPTS=(-s -k)
 
@@ -129,7 +129,7 @@ HTTP_CODE=$(curl "${CURL_OPTS[@]}" -c cookies.txt -D headers.txt \
 LOCATION=$(grep -i "^location:" headers.txt 2>/dev/null | head -1 | cut -d' ' -f2- | tr -d '\r\n')
 
 test_result "2.1 OIDC login returns redirect (302)" "$( [[ "$HTTP_CODE" == "302" ]] && echo true || echo false )"
-test_result "2.2 Redirect points to Authelia" "$( [[ "$LOCATION" == *"auth.${DOMAIN}"* ]] && echo true || echo false )"
+test_result "2.2 Redirect points to Authelia" "$( [[ "$LOCATION" == *"${DOMAIN}/auth"* ]] && echo true || echo false )"
 test_result "2.3 OIDC_STATE cookie is set" "$( grep -q "OIDC_STATE" cookies.txt && echo true || echo false )"
 
 #######################################
@@ -219,8 +219,8 @@ echo "--- Test 4: SSO Session Sharing ---"
 rm -f cookies_sso.txt
 cp cookies.txt cookies_sso.txt  # Keep Authelia session
 
-# Clear Signal K cookies
-grep -v "signalk" cookies_sso.txt > cookies_sso_clean.txt || true
+# Clear Signal K session cookies, keep Authelia session
+grep -v "JAUTHENTICATION\|OIDC_STATE" cookies_sso.txt > cookies_sso_clean.txt || true
 mv cookies_sso_clean.txt cookies_sso.txt
 
 # Start OIDC flow - should use existing Authelia session

--- a/tools/test-oidc-flow.sh
+++ b/tools/test-oidc-flow.sh
@@ -118,9 +118,9 @@ if [[ -z "$DOMAIN" ]]; then
     exit 1
 fi
 
-# Set up URLs
-SK_URL="https://signalk.${DOMAIN}"
-AUTH_URL="https://auth.${DOMAIN}"
+# Set up URLs (port-based routing uses path prefixes)
+SK_URL="https://${DOMAIN}/signalk-server"
+AUTH_URL="https://${DOMAIN}/auth"
 
 # Set up output directory
 if [[ -z "$OUTPUT_DIR" ]]; then

--- a/tools/test-sso-flow.sh
+++ b/tools/test-sso-flow.sh
@@ -6,7 +6,7 @@
 # can seamlessly access Signal K without re-authenticating.
 #
 # This tests the SSO (Single Sign-On) behavior - the Authelia session should be
-# shared across all subdomains (*.<domain>).
+# shared across all apps on the same domain.
 #
 # Usage:
 #   ./test-sso-flow.sh [options]
@@ -75,9 +75,9 @@ if [[ -z "$DOMAIN" ]]; then
     exit 1
 fi
 
-# URLs
-SK_URL="https://signalk.${DOMAIN}"
-AUTH_URL="https://auth.${DOMAIN}"
+# URLs (port-based routing uses path prefixes)
+SK_URL="https://${DOMAIN}/signalk-server"
+AUTH_URL="https://${DOMAIN}/auth"
 HOMARR_URL="https://${DOMAIN}"
 
 # Output directory
@@ -144,12 +144,12 @@ if grep -q "authelia_session" cookies.txt; then
     log_success "Authelia session cookie found"
     log_verbose "Cookie domain: $COOKIE_DOMAIN"
 
-    # Check if domain allows subdomain sharing
+    # Check if cookie domain matches
     if [[ "$COOKIE_DOMAIN" == ".${DOMAIN}" ]] || [[ "$COOKIE_DOMAIN" == "${DOMAIN}" ]]; then
-        log_success "Cookie domain allows subdomain sharing: $COOKIE_DOMAIN"
+        log_success "Cookie domain matches: $COOKIE_DOMAIN"
         add_result "Step 2: PASS - Session cookie with correct domain"
     else
-        log_warn "Cookie domain may not allow subdomain sharing: $COOKIE_DOMAIN"
+        log_warn "Cookie domain mismatch: $COOKIE_DOMAIN (expected ${DOMAIN})"
         add_result "Step 2: WARN - Cookie domain: $COOKIE_DOMAIN"
     fi
 else
@@ -201,13 +201,13 @@ log_verbose "Final location: $FINAL_LOCATION"
 # Check if we need to re-authenticate (SSO failure)
 if echo "$BODY_CONTENT" | grep -qi "sign in\|login\|password" && [[ "$HTTP_CODE" == "200" ]]; then
     log_error "SSO FAILED: Authelia is showing login page instead of using existing session"
-    log_error "This means the Authelia session cookie is not being shared across subdomains"
+    log_error "This means the Authelia session cookie is not being shared"
     add_result "Step 4: FAIL - SSO not working (login page shown)"
 
     echo ""
     echo "Debugging info:"
-    echo "- Check that Authelia session domain is set to '.${DOMAIN}' (with leading dot)"
-    echo "- Verify cookies are being sent to signalk.${DOMAIN}"
+    echo "- Check that Authelia session cookie domain is set correctly"
+    echo "- Verify cookies are being sent to ${DOMAIN}"
     echo ""
     echo "Current cookies:"
     cat cookies.txt


### PR DESCRIPTION
## Summary
- Update Signal K and Grafana OIDC configurations to use path-redirect URIs and new Authelia issuer URL (`halos.local/auth/`)
- Signal K reads external port from `/etc/halos/port-registry` for mDNS service advertisement
- Grafana uses `GF_AUTH_GENERIC_OAUTH_REDIRECT_URL` override for path-redirect callback URI
- Remove `routing.subdomain` from all 5 app metadata.yaml files
- Update extra_hosts from subdomain entries to base domain entries

## Motivation
Companion to halos-org/halos-core-containers port-based routing migration. Apps need updated OIDC configs and metadata to work with the new routing scheme.

Related: halos-org/halos-mdns-publisher#37

## Test plan
- [ ] Signal K OIDC login flow works end-to-end
- [ ] Grafana OIDC login flow works end-to-end
- [ ] SSO between Signal K and Grafana via shared Authelia session
- [ ] Signal K mDNS advertises correct port
- [ ] All 5 apps accessible via their assigned ports
- [ ] Path redirects work for all apps

🤖 Generated with [Claude Code](https://claude.com/claude-code)