### PR TITLE
Remove dead HTTP port config fields from marine container apps

### DIFF
--- a/apps/avnav/config.yml
+++ b/apps/avnav/config.yml
@@ -1,15 +1,3 @@
 version: "1.0"
 
-groups:
-  - id: network
-    label: Network Settings
-    description: Port configuration
-    fields:
-      - id: AVNAV_HTTP_PORT
-        label: HTTP Port
-        type: integer
-        default: 8082
-        min: 1024
-        max: 65535
-        required: true
-        description: Port for AvNav web interface
+groups: []

--- a/apps/avnav/metadata.yaml
+++ b/apps/avnav/metadata.yaml
@@ -1,6 +1,6 @@
 name: AvNav
 app_id: avnav
-version: 20251028-13
+version: 20251028-14
 upstream_version: "20251028"
 description: Touch-optimized chart plotter for sailing and motor yachts
 long_description: |

--- a/apps/influxdb/config.yml
+++ b/apps/influxdb/config.yml
@@ -1,19 +1,6 @@
 version: "1.0"
 
 groups:
-  - id: network
-    label: Network Settings
-    description: Port configuration
-    fields:
-      - id: INFLUXDB_HTTP_PORT
-        label: HTTP Port
-        type: integer
-        default: 8086
-        min: 1024
-        max: 65535
-        required: true
-        description: Port for web interface and API
-
   - id: database
     label: Database Settings
     description: Initial database configuration

--- a/apps/influxdb/metadata.yaml
+++ b/apps/influxdb/metadata.yaml
@@ -1,6 +1,6 @@
 name: InfluxDB
 app_id: influxdb
-version: 2.8.0-3
+version: 2.8.0-4
 upstream_version: 2.8.0
 description: Time-series database for marine data logging
 long_description: |

--- a/apps/opencpn/config.yml
+++ b/apps/opencpn/config.yml
@@ -1,26 +1,3 @@
 version: "1.0"
 
-groups:
-  - id: network
-    label: Network Settings
-    description: VNC web access configuration
-    fields:
-      - id: OPENCPN_VNC_PORT
-        label: VNC Web Port
-        type: integer
-        default: 8080
-        min: 1024
-        max: 65535
-        required: true
-        description: Port for accessing OpenCPN via web browser
-
-  - id: security
-    label: Security
-    description: VNC access credentials
-    fields:
-      - id: OPENCPN_VNC_PASSWORD
-        label: VNC Password
-        type: password
-        default: halos
-        required: true
-        description: Password to access OpenCPN via VNC
+groups: []

--- a/apps/opencpn/metadata.yaml
+++ b/apps/opencpn/metadata.yaml
@@ -1,6 +1,6 @@
 name: OpenCPN
 app_id: opencpn
-version: 5.12.4-13
+version: 5.12.4-14
 upstream_version: 5.12.4
 description: Open source chart plotter and navigation software
 long_description: |


### PR DESCRIPTION
## Summary

- Remove unused `AVNAV_HTTP_PORT`, `OPENCPN_VNC_PORT`, `OPENCPN_VNC_PASSWORD`, and `INFLUXDB_HTTP_PORT` config fields
- These fields were never consumed by docker-compose or container runtime — web UIs are accessed through Traefik, making host port config unnecessary and misleading
- Bump app versions for avnav, opencpn, and influxdb

## Test plan

- [ ] Verify CI passes (build-all, version-bump-check)
- [ ] Deploy updated packages to test device and confirm apps still accessible via Traefik
- [ ] Verify config UI no longer shows dead port fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)