### PR TITLE
Fix Grafana OIDC authentication with Authelia

### DIFF
--- a/apps/grafana/docker-compose.yml
+++ b/apps/grafana/docker-compose.yml
@@ -9,10 +9,9 @@ services:
       # Allow Grafana to resolve HALOS_DOMAIN for OIDC (mDNS doesn't work in containers)
       - "${HALOS_DOMAIN}:host-gateway"
     environment:
-      # Server URL for OAuth redirects — uses port URL when available
-      - GF_SERVER_ROOT_URL=https://${HALOS_DOMAIN}:${HALOS_EXTERNAL_PORT:-443}
-      # Override OAuth redirect URI to use path redirect (survives 302 to port URL)
-      - GF_AUTH_GENERIC_OAUTH_REDIRECT_URL=https://${HALOS_DOMAIN}/grafana/login/generic_oauth
+      # Server URL — must match the port-based URL that users actually access
+      # Grafana derives the OIDC redirect_uri from this (there is no separate setting)
+      - GF_SERVER_ROOT_URL=https://${HALOS_DOMAIN}:${HALOS_EXTERNAL_PORT}
       # OAuth configuration for Authelia SSO
       - GF_AUTH_GENERIC_OAUTH_ENABLED=true
       - GF_AUTH_GENERIC_OAUTH_NAME=HaLOS SSO
@@ -33,8 +32,11 @@ services:
       # Required for self-signed Traefik certs. Acceptable for local-only device.
       - GF_AUTH_GENERIC_OAUTH_TLS_SKIP_VERIFY_INSECURE=true
       - GF_AUTH_GENERIC_OAUTH_ALLOW_SIGN_UP=true
-      # Role mapping: Authelia 'admins' group -> Grafana Admin role
-      - "GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_PATH=contains(groups[*], 'admins') && 'Admin' || 'Viewer'"
+      # Role mapping: Authelia 'admins' group -> Grafana Admin, others get default Viewer
+      # Must NOT have a fallback (|| 'Viewer') — Grafana evaluates against the ID token
+      # first, and a fallback would always match there (no groups claim), preventing
+      # Grafana from checking the userinfo endpoint where groups actually exist.
+      - "GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_PATH=contains(groups[*], 'admins') && 'Admin'"
       - GF_AUTH_GENERIC_OAUTH_ALLOW_ASSIGN_GRAFANA_ADMIN=false
     logging:
       driver: journald

--- a/apps/grafana/metadata.yaml
+++ b/apps/grafana/metadata.yaml
@@ -1,6 +1,6 @@
 name: Grafana
 app_id: grafana
-version: 12.4.2-1
+version: 12.4.2-2
 upstream_version: 12.4.2
 description: Data visualization and monitoring platform
 long_description: |

--- a/apps/grafana/prestart.sh
+++ b/apps/grafana/prestart.sh
@@ -26,6 +26,11 @@ if [ -f "${PORT_REGISTRY}" ]; then
     EXTERNAL_PORT=$(grep "^grafana=" "${PORT_REGISTRY}" 2>/dev/null | cut -d= -f2)
 fi
 
+if [ -z "${EXTERNAL_PORT}" ]; then
+    echo "ERROR: Grafana external port not found in ${PORT_REGISTRY}"
+    exit 1
+fi
+
 # Write runtime env file with expanded HALOS_DOMAIN
 RUNTIME_ENV_DIR="/run/container-apps/marine-grafana-container"
 mkdir -p "${RUNTIME_ENV_DIR}"
@@ -37,25 +42,22 @@ EOF
 chmod 600 "${RUNTIME_ENV_DIR}/runtime.env"
 
 # Install OIDC client snippet for Authelia
-# Always written (not guarded) so redirect URIs stay current across upgrades
+# Redirect URI uses the port-based URL that Grafana derives from GF_SERVER_ROOT_URL
 OIDC_CLIENTS_DIR="/etc/halos/oidc-clients.d"
 OIDC_CLIENT_SNIPPET="${OIDC_CLIENTS_DIR}/grafana.yml"
 mkdir -p "${OIDC_CLIENTS_DIR}"
-cat > "${OIDC_CLIENT_SNIPPET}" << 'EOF'
+cat > "${OIDC_CLIENT_SNIPPET}" << EOF
 # Grafana OIDC Client Snippet
 # Installed by marine-grafana-container prestart.sh
-# Authelia's prestart script merges all snippets into oidc-clients.yml
-# Redirect URI uses path redirect (/grafana/) which 302s to the port URL
 
 client_id: grafana
 client_name: Grafana
 client_secret_file: /var/lib/container-apps/marine-grafana-container/data/oidc-secret
 redirect_uris:
-  - 'https://${HALOS_DOMAIN}/grafana/login/generic_oauth'
+  - 'https://${HALOS_DOMAIN}:${EXTERNAL_PORT}/login/generic_oauth'
 scopes: [openid, profile, email, groups]
 consent_mode: implicit
 token_endpoint_auth_method: client_secret_basic
-# Note: PKCE is enforced client-side via GF_AUTH_GENERIC_OAUTH_USE_PKCE=true
 EOF
 
 # Ensure data directory exists and has correct ownership (Grafana runs as UID 472)


### PR DESCRIPTION
## Summary

- Fix redirect_uri mismatch: use actual port from registry in `GF_SERVER_ROOT_URL` (no `:443` fallback), remove non-functional `GF_AUTH_GENERIC_OAUTH_REDIRECT_URL`, and write OIDC snippet with resolved port-based redirect URI
- Fix role mapping: remove `|| 'Viewer'` fallback from JMESPath expression so Grafana falls through from ID token (no groups) to userinfo endpoint (has groups) for role evaluation
- Fail prestart if external port is not found in port registry (prevents silent misconfiguration)

## Test plan

- [x] Verified on halosdev.local: OIDC login flow completes successfully
- [x] Verified Authelia accepts the redirect_uri (no more `invalid_client`)
- [x] Verified OIDC user gets Admin role when in Authelia `admins` group

🤖 Generated with [Claude Code](https://claude.com/claude-code)