### PR TITLE
Auto-provision InfluxDB datasource in Grafana

### DIFF
--- a/apps/grafana/assets/influxdb-datasource.yaml
+++ b/apps/grafana/assets/influxdb-datasource.yaml
@@ -1,0 +1,15 @@
+apiVersion: 1
+
+datasources:
+  - name: InfluxDB
+    type: influxdb
+    access: proxy
+    url: http://influxdb:8086
+    jsonData:
+      version: Flux
+      organization: marine
+      defaultBucket: marine
+    secureJsonData:
+      token: $__env{INFLUXDB_TOKEN}
+    isDefault: true
+    editable: true

--- a/apps/grafana/docker-compose.yml
+++ b/apps/grafana/docker-compose.yml
@@ -38,6 +38,8 @@ services:
       # Grafana from checking the userinfo endpoint where groups actually exist.
       - "GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_PATH=contains(groups[*], 'admins') && 'Admin'"
       - GF_AUTH_GENERIC_OAUTH_ALLOW_ASSIGN_GRAFANA_ADMIN=false
+      # InfluxDB datasource token (provisioned conditionally by prestart.sh)
+      - INFLUXDB_TOKEN=${INFLUXDB_TOKEN:-}
     logging:
       driver: journald
       options:
@@ -46,3 +48,4 @@ services:
     # halos-proxy-network is auto-injected by container-packaging-tools
     volumes:
       - ${CONTAINER_DATA_ROOT}/data:/var/lib/grafana
+      - ${CONTAINER_DATA_ROOT}/provisioning/datasources:/etc/grafana/provisioning/datasources:ro

--- a/apps/grafana/metadata.yaml
+++ b/apps/grafana/metadata.yaml
@@ -1,6 +1,6 @@
 name: Grafana
 app_id: grafana
-version: 12.4.2-2
+version: 12.4.2-3
 upstream_version: 12.4.2
 description: Data visualization and monitoring platform
 long_description: |

--- a/apps/grafana/prestart.sh
+++ b/apps/grafana/prestart.sh
@@ -65,4 +65,32 @@ EOF
 mkdir -p "${CONTAINER_DATA_ROOT}/data"
 chown -R 472:472 "${CONTAINER_DATA_ROOT}/data"
 
+# --- InfluxDB datasource provisioning ---
+
+INFLUXDB_ENV="/etc/container-apps/marine-influxdb-container/env"
+PROVISIONING_DIR="${CONTAINER_DATA_ROOT}/provisioning/datasources"
+DATASOURCE_SRC="/var/lib/container-apps/marine-grafana-container/assets/influxdb-datasource.yaml"
+DATASOURCE_DST="${PROVISIONING_DIR}/influxdb.yaml"
+
+mkdir -p "${PROVISIONING_DIR}"
+
+if [ -f "${INFLUXDB_ENV}" ]; then
+    # Extract only the token — avoid sourcing the entire file
+    INFLUXDB_ADMIN_TOKEN=$(grep '^INFLUXDB_ADMIN_TOKEN=' "${INFLUXDB_ENV}" | cut -d= -f2-)
+
+    if [ -n "${INFLUXDB_ADMIN_TOKEN}" ] && [ -f "${DATASOURCE_SRC}" ]; then
+        echo "InfluxDB detected -- provisioning datasource"
+        cp "${DATASOURCE_SRC}" "${DATASOURCE_DST}"
+        # Pass token to Grafana container via runtime.env
+        echo "INFLUXDB_TOKEN=${INFLUXDB_ADMIN_TOKEN}" >> "${RUNTIME_ENV_DIR}/runtime.env"
+    else
+        [ ! -f "${DATASOURCE_SRC}" ] && echo "WARNING: InfluxDB datasource template not found at ${DATASOURCE_SRC}"
+        rm -f "${DATASOURCE_DST}"
+    fi
+else
+    rm -f "${DATASOURCE_DST}"
+fi
+
+chown -R 472:472 "${PROVISIONING_DIR}"
+
 echo "Grafana prestart complete"


### PR DESCRIPTION
## Summary

- Auto-configure InfluxDB as a Grafana datasource when both containers are installed
- Ship provisioning YAML as a package asset; prestart.sh conditionally copies it into place
- Token passed via environment variable using Grafana's `$__env{INFLUXDB_TOKEN}` syntax
- Stale provisioning file removed if InfluxDB is uninstalled

## Test plan

- [x] Verified on halosdev.local: datasource appears in Grafana UI
- [x] "Save & test" shows "datasource is working. 3 buckets found"
- [x] Token resolved correctly from InfluxDB's env file
- [ ] Verify InfluxDB-absent scenario (remove InfluxDB env, restart Grafana)

🤖 Generated with [Claude Code](https://claude.com/claude-code)