### PR TITLE
Use InfluxQL for provisioned Grafana datasource

### DIFF
--- a/apps/grafana/assets/influxdb-datasource.yaml
+++ b/apps/grafana/assets/influxdb-datasource.yaml
@@ -5,11 +5,11 @@ datasources:
     type: influxdb
     access: proxy
     url: http://influxdb:8086
+    database: marine
     jsonData:
-      version: Flux
-      organization: marine
-      defaultBucket: marine
+      httpMode: POST
+      httpHeaderName1: Authorization
     secureJsonData:
-      token: $__env{INFLUXDB_TOKEN}
+      httpHeaderValue1: Token $__env{INFLUXDB_TOKEN}
     isDefault: true
     editable: true

--- a/apps/grafana/metadata.yaml
+++ b/apps/grafana/metadata.yaml
@@ -1,6 +1,6 @@
 name: Grafana
 app_id: grafana
-version: 12.4.2-3
+version: 12.4.2-4
 upstream_version: 12.4.2
 description: Data visualization and monitoring platform
 long_description: |


### PR DESCRIPTION
## Summary

- Switch provisioned InfluxDB datasource from Flux to InfluxQL
- Token passed via custom HTTP Authorization header (InfluxQL auth model)
- InfluxDB 2.x auto-creates DBRP mappings so `marine` bucket is accessible as database `marine`

## Test plan

- [x] Verified on halosdev.local: "datasource is working. 0 measurements found"
- [x] DBRP mapping confirmed: `marine` bucket mapped as database `marine` with `autogen` retention policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)