### PR TITLE
Auto-install Signal K to InfluxDB plugin

### DIFF
--- a/apps/influxdb/docker-compose.yml
+++ b/apps/influxdb/docker-compose.yml
@@ -8,8 +8,10 @@ services:
       driver: journald
       options:
         tag: "{{.Name}}"
-    # No direct port exposure - access via Traefik at influxdb.{hostname}.local
-    # halos-proxy-network is auto-injected by container-packaging-tools
+    # Expose API on localhost for host-network containers (Signal K)
+    # External access goes through Traefik (halos-proxy-network is auto-injected)
+    ports:
+      - "127.0.0.1:8086:8086"
     volumes:
       - ${CONTAINER_DATA_ROOT}/config:/etc/influxdb2
       - ${CONTAINER_DATA_ROOT}/db:/var/lib/influxdb2

--- a/apps/influxdb/metadata.yaml
+++ b/apps/influxdb/metadata.yaml
@@ -1,6 +1,6 @@
 name: InfluxDB
 app_id: influxdb
-version: 2.8.0-5
+version: 2.8.0-6
 upstream_version: 2.8.0
 description: Time-series database for marine data logging
 long_description: |

--- a/apps/signalk-server/metadata.yaml
+++ b/apps/signalk-server/metadata.yaml
@@ -1,6 +1,6 @@
 name: Signal K Server
 app_id: signalk-server
-version: 2.24.0-1
+version: 2.24.0-2
 upstream_version: 2.24.0
 description: Signal K server for marine data processing and routing
 long_description: |

--- a/apps/signalk-server/prestart.sh
+++ b/apps/signalk-server/prestart.sh
@@ -113,6 +113,73 @@ consent_mode: implicit
 token_endpoint_auth_method: client_secret_post
 EOF
 
+# --- InfluxDB plugin provisioning ---
+
+INFLUXDB_ENV="/etc/container-apps/marine-influxdb-container/env"
+PLUGIN_CONFIG_DIR="${SIGNALK_DATA}/plugin-config-data"
+PLUGIN_CONFIG="${PLUGIN_CONFIG_DIR}/signalk-to-influxdb2.json"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [ -f "${INFLUXDB_ENV}" ]; then
+    INFLUXDB_ADMIN_TOKEN=$(grep '^INFLUXDB_ADMIN_TOKEN=' "${INFLUXDB_ENV}" | cut -d= -f2-)
+
+    if [ -n "${INFLUXDB_ADMIN_TOKEN}" ]; then
+        # Install plugin if not already present
+        if [ ! -d "${SIGNALK_DATA}/node_modules/signalk-to-influxdb2" ]; then
+            SIGNALK_IMAGE=$(grep -oP 'image:\s*\K\S+' "${SCRIPT_DIR}/docker-compose.yml" | head -1)
+            echo "Installing signalk-to-influxdb2 plugin..."
+            if timeout 120 docker run --rm --entrypoint npm \
+                -v "${SIGNALK_DATA}:/home/node/.signalk" \
+                -u 1000:1000 \
+                "${SIGNALK_IMAGE}" \
+                install --prefix /home/node/.signalk signalk-to-influxdb2; then
+                echo "Plugin installed successfully"
+            else
+                echo "WARNING: Failed to install signalk-to-influxdb2 (no internet?). Will retry on next restart."
+            fi
+        fi
+
+        # Write plugin config (first time only) or update token
+        mkdir -p "${PLUGIN_CONFIG_DIR}"
+        if [ ! -f "${PLUGIN_CONFIG}" ]; then
+            cat > "${PLUGIN_CONFIG}" << PLUGINEOF
+{
+  "enabled": true,
+  "configuration": {
+    "influxes": [
+      {
+        "url": "http://localhost:8086",
+        "token": "${INFLUXDB_ADMIN_TOKEN}",
+        "org": "marine",
+        "bucket": "marine",
+        "onlySelf": true,
+        "resolution": 1000
+      }
+    ]
+  }
+}
+PLUGINEOF
+            echo "InfluxDB plugin configured"
+        else
+            # Update token in existing config without overwriting other settings
+            if python3 -c "
+import json, sys
+with open('${PLUGIN_CONFIG}', 'r') as f:
+    cfg = json.load(f)
+influxes = cfg.get('configuration', {}).get('influxes', [])
+if influxes:
+    influxes[0]['token'] = '${INFLUXDB_ADMIN_TOKEN}'
+with open('${PLUGIN_CONFIG}', 'w') as f:
+    json.dump(cfg, f, indent=2)
+"; then
+                echo "InfluxDB plugin token updated"
+            else
+                echo "WARNING: Failed to update InfluxDB token in plugin config"
+            fi
+        fi
+    fi
+fi
+
 # Ensure data directory is owned by node user (UID 1000)
 # settings.json is installed via default-data/ at package install time
 # The container runs as node:node, but prestart runs as root


### PR DESCRIPTION
## Summary

- Auto-install and configure `signalk-to-influxdb2` plugin when both Signal K and InfluxDB are installed
- Plugin installed via `docker run --entrypoint npm` using the same Signal K image (avoids running the server entrypoint)
- Plugin config written with InfluxDB token from `/etc/container-apps/marine-influxdb-container/env`
- Token updated on subsequent restarts without overwriting user-customized settings
- Fails gracefully if npm install fails (no internet) — retries on next restart
- Expose InfluxDB port 8086 on `127.0.0.1` for host-network container access (Signal K uses `network_mode: host`)

## Test plan

- [x] Plugin installed and visible in Signal K Admin UI → Plugin Configuration
- [x] Plugin enabled with correct InfluxDB URL (`http://localhost:8086`), token, org (`marine`), bucket (`marine`)
- [x] InfluxDB reachable on `localhost:8086` from host
- [ ] Verify data flows when actual marine data sources are connected

🤖 Generated with [Claude Code](https://claude.com/claude-code)