### PR TITLE
Add Docker healthcheck to Signal K container

### DIFF
--- a/apps/signalk-server/docker-compose.yml
+++ b/apps/signalk-server/docker-compose.yml
@@ -36,6 +36,12 @@ services:
       - /run:/run
     group_add:
       - "960"  # halpid group for /run/halpid/halpid.sock access
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:3000/signalk || exit 1"]
+      interval: 30s
+      timeout: 10s
+      start_period: 60s
+      retries: 3
     privileged: true
     security_opt:
       - no-new-privileges:false

--- a/apps/signalk-server/metadata.yaml
+++ b/apps/signalk-server/metadata.yaml
@@ -1,6 +1,6 @@
 name: Signal K Server
 app_id: signalk-server
-version: 2.24.0-2
+version: 2.24.0-3
 upstream_version: 2.24.0
 description: Signal K server for marine data processing and routing
 long_description: |


### PR DESCRIPTION
## Summary

- Adds a Docker healthcheck to the Signal K container that probes `/signalk` every 30 seconds
- Enables automatic recovery via autoheal (added in halos-org/halos-core-containers) when the server becomes unresponsive

## Motivation

Signal K's admin UI restart button hangs the server when WebSocket connections are active (SignalK/signalk-server#2589). The process stays alive but the event loop is starved, so `process.exit(0)` never fires. Without a healthcheck, there is no way to detect or recover from this state automatically.

## Test plan

- [x] Deployed to halosdev.local
- [x] Health check shows "healthy" during normal operation
- [x] After triggering the restart hang, container transitions to "unhealthy" within ~90 seconds
- [x] Autoheal detects unhealthy state and restarts the container automatically
- [x] Server comes back up healthy after restart

Refs: SignalK/signalk-server#2589, closes #163 (partially — Signal K only, other containers tracked separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)