### PR TITLE
Add Docker healthchecks to Grafana, InfluxDB, and AvNav

### DIFF
--- a/apps/avnav/docker-compose.yml
+++ b/apps/avnav/docker-compose.yml
@@ -23,5 +23,11 @@ services:
       - GID=1000
     extra_hosts:
       - "host.docker.internal:host-gateway"
+    healthcheck:
+      test: ["CMD-SHELL", "python3 -c \"import urllib.request; urllib.request.urlopen('http://localhost:8080/', timeout=2)\""]
+      interval: 10s
+      timeout: 5s
+      start_period: 10s
+      retries: 3
     user: "1000:1000"
     privileged: true

--- a/apps/avnav/metadata.yaml
+++ b/apps/avnav/metadata.yaml
@@ -1,6 +1,6 @@
 name: AvNav
 app_id: avnav
-version: 20251028-14
+version: 20251028-15
 upstream_version: "20251028"
 description: Touch-optimized chart plotter for sailing and motor yachts
 long_description: |

--- a/apps/grafana/docker-compose.yml
+++ b/apps/grafana/docker-compose.yml
@@ -40,6 +40,12 @@ services:
       - GF_AUTH_GENERIC_OAUTH_ALLOW_ASSIGN_GRAFANA_ADMIN=false
       # InfluxDB datasource token (provisioned conditionally by prestart.sh)
       - INFLUXDB_TOKEN=${INFLUXDB_TOKEN:-}
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:3000/api/health"]
+      interval: 10s
+      timeout: 5s
+      start_period: 30s
+      retries: 3
     logging:
       driver: journald
       options:

--- a/apps/grafana/metadata.yaml
+++ b/apps/grafana/metadata.yaml
@@ -1,6 +1,6 @@
 name: Grafana
 app_id: grafana
-version: 12.4.2-4
+version: 12.4.2-5
 upstream_version: 12.4.2
 description: Data visualization and monitoring platform
 long_description: |

--- a/apps/influxdb/docker-compose.yml
+++ b/apps/influxdb/docker-compose.yml
@@ -24,3 +24,9 @@ services:
       - DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=${INFLUXDB_ADMIN_TOKEN:-halos-default-token-change-in-production}
       - DOCKER_INFLUXD_QUERY_CONCURRENCY=1
       - DOCKER_INFLUXD_QUERY_MEMORY_BYTES=20971520
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:8086/health"]
+      interval: 10s
+      timeout: 5s
+      start_period: 30s
+      retries: 3

--- a/apps/influxdb/metadata.yaml
+++ b/apps/influxdb/metadata.yaml
@@ -1,6 +1,6 @@
 name: InfluxDB
 app_id: influxdb
-version: 2.8.0-6
+version: 2.8.0-7
 upstream_version: 2.8.0
 description: Time-series database for marine data logging
 long_description: |


### PR DESCRIPTION
## Summary

- Add healthcheck to Grafana using its built-in `/api/health` endpoint
- Add healthcheck to InfluxDB using its built-in `/health` endpoint
- Add healthcheck to AvNav using a python3 urllib probe (no curl/wget in image)
- All include appropriate `start_period` values for their startup characteristics

Combined with the autoheal container in halos-core-containers, this enables automatic restart of unresponsive marine services.

Closes #165

## Test plan

- [ ] Deploy and verify `docker inspect grafana` shows healthcheck config
- [ ] Verify `docker inspect influxdb` shows healthcheck config
- [ ] Verify `docker inspect avnav` shows healthcheck config
- [ ] Confirm all three containers reach `healthy` status (`docker ps`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)