### PR TITLE
fix(grafana): preserve ${HALOS_DOMAIN} placeholder in OIDC client snippet

### DIFF
--- a/apps/grafana/metadata.yaml
+++ b/apps/grafana/metadata.yaml
@@ -1,6 +1,6 @@
 name: Grafana
 app_id: grafana
-version: 13.0.1-1
+version: 13.0.1-2
 upstream_version: 13.0.1
 description: Data visualization and monitoring platform
 long_description: |

--- a/apps/grafana/prestart.sh
+++ b/apps/grafana/prestart.sh
@@ -49,12 +49,18 @@ mkdir -p "${OIDC_CLIENTS_DIR}"
 cat > "${OIDC_CLIENT_SNIPPET}" << EOF
 # Grafana OIDC Client Snippet
 # Installed by marine-grafana-container prestart.sh
+#
+# \${HALOS_DOMAIN} is preserved as a literal placeholder (escaped \\\$ in
+# the unquoted heredoc). halos-core-containers' OIDC merger expands it
+# to one redirect_uri per configured DNS hostname at merge time.
+# \${EXTERNAL_PORT} is the prestart-resolved port and substitutes at
+# write time.
 
 client_id: grafana
 client_name: Grafana
 client_secret_file: /var/lib/container-apps/marine-grafana-container/data/oidc-secret
 redirect_uris:
-  - 'https://${HALOS_DOMAIN}:${EXTERNAL_PORT}/login/generic_oauth'
+  - 'https://\${HALOS_DOMAIN}:${EXTERNAL_PORT}/login/generic_oauth'
 scopes: [openid, profile, email, groups]
 consent_mode: implicit
 token_endpoint_auth_method: client_secret_basic


### PR DESCRIPTION
## Summary

Fix a heredoc-escaping bug in Grafana's prestart so the OIDC client snippet preserves `${HALOS_DOMAIN}` as a literal placeholder. Pairs with halos-org/halos-core-containers#122 (multi-hostname Traefik support), which introduces a merger that expands the placeholder to one `redirect_uri` per configured DNS hostname.

## What changes

- `apps/grafana/prestart.sh`: change the unquoted heredoc body so `${HALOS_DOMAIN}` is escaped (`\${HALOS_DOMAIN}`). `${EXTERNAL_PORT}` stays unescaped and continues to substitute at write time.
- `apps/grafana/metadata.yaml`: bump app version `13.0.1-1` → `13.0.1-2`.

## Why

Today the heredoc substitutes `${HALOS_DOMAIN}` at write time, baking a single canonical hostname into `/etc/halos/oidc-clients.d/grafana.yml`. With the new multi-hostname merger in `halos-core-containers`, snippets must keep the literal placeholder so the merger can expand it once per configured DNS hostname. Without this fix, Grafana OIDC login works only via the canonical hostname even after the rest of HaLOS is multi-hostname-aware.

## Pattern reference

Sibling apps in this repo:
- `apps/signalk-server/prestart.sh:100` already uses `<<'EOF'` (fully-quoted heredoc) — correct, but cannot be applied here because the heredoc also needs `${EXTERNAL_PORT}` substituted at write time.
- `apps/avnav/prestart.sh` and `apps/influxdb/prestart.sh` write env files but no OIDC client snippets — no change needed.

This is the only marine-containers app affected by Unit 8 of the multi-hostname plan (`docs/plans/2026-04-28-001-feat-multi-hostname-traefik-plan.md` §467).

## Backward compatibility

The merger in halos-core-containers handles snippets without the placeholder by passing them through unchanged, and snippets with the placeholder by expanding per DNS hostname. Ship-order considerations:
- If this PR merges and ships **before** halos-core-containers v0.3.0 lands on the device: the existing single-canonical merger sees a literal `${HALOS_DOMAIN}` it doesn't recognize → Authelia rejects the redirect_uri → Grafana OIDC login breaks until the core update arrives.
- Expected order: halos-core-containers v0.3.0 first, then this fix. Coordinate during release.

## Testing

- Smoke-tested the heredoc locally: `${HALOS_DOMAIN}` survives as a literal, `${EXTERNAL_PORT}` substitutes correctly.
- End-to-end Grafana OIDC login from a non-canonical hostname will be verified once both PRs are deployed to halosdev.local.

## Post-Deploy Monitoring & Validation

- **Validate on a deployed device**: `grep '\${HALOS_DOMAIN}' /etc/halos/oidc-clients.d/grafana.yml` should find the literal placeholder.
- **After core merger runs** (apt install/remove of halos-core-containers): `grep -A4 'client_id: grafana' /var/lib/container-apps/halos-core-containers/data/authelia/oidc-clients.yml` shows N `redirect_uris` (one per configured DNS hostname).
- **Failure signal**: if Grafana OIDC login returns "invalid_redirect_uri" after deploying both PRs, the merger likely didn't expand the placeholder — check Authelia logs for the actual redirect_uri it received and verify it's in the merged client config.
- **Owner**: matti.airas@hatlabs.fi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)