### PR TITLE
chore(apps): bump debian revision on routed apps to pull in path-only TOMLs

### DIFF
--- a/apps/avnav/metadata.yaml
+++ b/apps/avnav/metadata.yaml
@@ -1,6 +1,6 @@
 name: AvNav
 app_id: avnav
-version: 20251028-15
+version: 20251028-16
 upstream_version: "20251028"
 description: Touch-optimized chart plotter for sailing and motor yachts
 long_description: |

--- a/apps/grafana/metadata.yaml
+++ b/apps/grafana/metadata.yaml
@@ -1,6 +1,6 @@
 name: Grafana
 app_id: grafana
-version: 13.0.1-2
+version: 13.0.1-3
 upstream_version: 13.0.1
 description: Data visualization and monitoring platform
 long_description: |

--- a/apps/influxdb/metadata.yaml
+++ b/apps/influxdb/metadata.yaml
@@ -1,6 +1,6 @@
 name: InfluxDB
 app_id: influxdb
-version: 2.9.1-1
+version: 2.9.1-2
 upstream_version: 2.9.1
 description: Time-series database for marine data logging
 long_description: |

--- a/apps/opencpn/metadata.yaml
+++ b/apps/opencpn/metadata.yaml
@@ -1,6 +1,6 @@
 name: OpenCPN
 app_id: opencpn
-version: 5.12.4-14
+version: 5.12.4-15
 upstream_version: 5.12.4
 description: Open source chart plotter and navigation software
 long_description: |

--- a/apps/signalk-server/metadata.yaml
+++ b/apps/signalk-server/metadata.yaml
@@ -1,6 +1,6 @@
 name: Signal K Server
 app_id: signalk-server
-version: 2.27.0-1
+version: 2.27.0-2
 upstream_version: 2.27.0
 description: Signal K server for marine data processing and routing
 long_description: |


### PR DESCRIPTION
## Why

This rebuild has a **dual purpose** now that [halos-org/container-packaging-tools#203](https://github.com/halos-org/container-packaging-tools/pull/203) has landed and CPT v0.6.0 is the current main:

1. **Push the path-only TOMLs through apt.** CPT v0.5.8 changed routed apps to emit `url = "/{app_id}/"` instead of `url = "https://{{domain}}/{app_id}/"`. Without a revision bump, apt.halos.fi rejects the rebuilt .debs as "already in pool" (the workflow keys on filename = `name_version`, not content SHA), so the new TOMLs never reach devices. Per-app revision bumps force apt to accept the new content.

2. **Pick up the new Homarr-stack `Breaks:` auto-injection.** CPT v0.6.0 (released today) auto-injects `Breaks: homarr-container-adapter (<< 0.4.6), halos-core-containers (<< 0.3.2)` into the generated `debian/control` for every routed visible web app. The marine build pulls CPT from git `main`, so the rebuild produced by these revision bumps will include the new Breaks lines without any additional change here. The Breaks lines close the silent-missing-card failure mode when a user installs a single marine app onto an older HaLOS system (Cockpit App Store / raw `apt install`) — apt now auto-upgrades the peer or refuses with a clear error instead of failing silently.

The rationale for both pieces is documented in:
- [`docs/solutions/best-practices/2026-05-13-prefer-breaks-over-depends-for-partial-upgrade-gating.md`](https://github.com/halos-org/halos/blob/main/docs/solutions/best-practices/2026-05-13-prefer-breaks-over-depends-for-partial-upgrade-gating.md)
- [`docs/solutions/best-practices/2026-04-30-skip-apt-depends-pins-sibling-halos-packages.md`](https://github.com/halos-org/halos/blob/main/docs/solutions/best-practices/2026-04-30-skip-apt-depends-pins-sibling-halos-packages.md) — Keep-the-pin branch.

## Affected apps

All apps with `routing:` in `metadata.yaml` (served through Traefik path-prefix on :443):

| App | Before | After |
|---|---|---|
| signalk-server | 2.27.0-1 | 2.27.0-2 |
| avnav | 20251028-15 | 20251028-16 |
| grafana | 13.0.1-2 | 13.0.1-3 |
| influxdb | 2.9.1-1 | 2.9.1-2 |
| opencpn | 5.12.4-14 | 5.12.4-15 |

Non-routed apps are unaffected — their generated TOMLs continue to use the `{{domain}}` template (path-only doesn't apply with a port), and CPT does not inject Breaks for them.

## Verification

Before publishing the resulting draft release: extract one of the rebuilt .debs (e.g. `marine-signalk-server-container_2.27.0-2_all.deb`) and confirm:

1. `/etc/halos/webapps.d/marine-signalk-server-container.toml` contains `url = "/signalk-server/"` (path-only).
2. `debian/control` (from `control.tar.zst`) contains `Breaks: homarr-container-adapter (<< 0.4.6), halos-core-containers (<< 0.3.2)`.

If both are present, the rebuild has served both purposes and the draft can be published as Latest.