### PR TITLE
docs(AGENTS): point to workspace VERSION-bump policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,10 @@ Individual apps in `apps/` have their own versions in `metadata.yaml`. These are
 - **`.github/scripts/calculate-revision.sh`**: Query git tags to find next N
 - **`.github/scripts/generate-changelog.sh`**: No-op (preserves committed changelog)
 
-**CI Enforcement**: PRs that change app files in `apps/<app>/` must include a bump to the `version` field in `apps/<app>/metadata.yaml`, or CI will fail. Changes outside `apps/` that affect the package also require a VERSION file bump.
+**CI Enforcement**:
+
+- **App-level (per PR)**: PRs that change files in `apps/<app>/` must bump the `version` field in `apps/<app>/metadata.yaml`, or CI will fail.
+- **Repo-level (per release cycle)**: `VERSION` bumps are *per release cycle*, not per PR — see the workspace policy in `halos/AGENTS.md`. Default: do NOT bump `VERSION` in feature PRs; CI auto-increments the `+N` revision in tags between releases (this repo is the gold-standard example: a single `VERSION` of `0.3.2` has shipped twelve `+N` prereleases). Bump `VERSION` only when starting a new release cycle (when `VERSION` matches the latest stable tag).
 
 ## What This Repository Contains
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ cd halos
 ./run repos:clone
 ```
 
-See `halos/docs/` for development workflows and guidance.
+See the [halos workspace](https://github.com/halos-org/halos) for development workflows and guidance.
 
 ## About This Project
 
@@ -222,6 +222,6 @@ For testing that invalid authentication attempts are properly rejected (malforme
 
 ## Related
 
-- **Parent**: [../AGENTS.md](../AGENTS.md) - Workspace documentation
+- **Workspace**: [halos](https://github.com/halos-org/halos) - Multi-repo development hub
 - **Tooling**: [container-packaging-tools](https://github.com/halos-org/container-packaging-tools)
 - **UI**: [cockpit-apt](https://github.com/halos-org/cockpit-apt)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ Individual apps in `apps/` have their own versions in `metadata.yaml`. These are
 **CI Enforcement**:
 
 - **App-level (per PR)**: PRs that change files in `apps/<app>/` must bump the `version` field in `apps/<app>/metadata.yaml`, or CI will fail.
-- **Repo-level (per release cycle)**: `VERSION` bumps are *per release cycle*, not per PR — see the workspace policy in `halos/AGENTS.md`. Default: do NOT bump `VERSION` in feature PRs; CI auto-increments the `+N` revision in tags between releases (this repo is the gold-standard example: a single `VERSION` of `0.3.2` has shipped twelve `+N` prereleases). Bump `VERSION` only when starting a new release cycle (when `VERSION` matches the latest stable tag).
+- **Repo-level (per release cycle)**: `VERSION` bumps are *per release cycle*, not per PR. Default: do NOT bump `VERSION` in feature PRs — CI auto-increments the `+N` revision in release tags (e.g., `v0.3.2+1`, `+2`, `+3`) between stable releases. This repo is a clean example: a single `VERSION` of `0.3.2` has shipped twelve `+N` prereleases. Bump `VERSION` only when starting a new release cycle, i.e., when `VERSION` currently matches the latest stable tag and this PR is opening the next cycle. If `VERSION` already differs from the latest stable tag, no further bump is needed regardless of how many package-affecting files this PR touches.
 
 ## What This Repository Contains
 


### PR DESCRIPTION
## Summary

Inline the conditional VERSION-bump rule directly in this repo's `AGENTS.md`:

- App-level bumps remain per-PR (unchanged).
- Repo-level `VERSION` bumps are per release cycle (default: do NOT bump in feature PRs; CI walks the `+N` revision automatically).

The wording is self-contained — no reference to the workspace, so the rule remains intact when this repo is cloned standalone.

## Why

This repo already follows the right pattern in practice (`VERSION=0.3.2` has shipped twelve `+N` prereleases — the gold standard). The doc just didn't match. Calling out this repo's own behaviour as the example helps codify it.

Refs halos-org/halos#113