### PR TITLE
Move Signal K Server dashboard tile to origin (0,0)

### DIFF
--- a/apps/signalk-server/metadata.yaml
+++ b/apps/signalk-server/metadata.yaml
@@ -1,6 +1,6 @@
 name: Signal K Server
 app_id: signalk-server
-version: 2.27.0-2
+version: 2.27.0-3
 upstream_version: 2.27.0
 description: Signal K server for marine data processing and routing
 long_description: |
@@ -41,7 +41,7 @@ layout:
   width: 2
   height: 2
   x_offset: 0
-  y_offset: 1
+  y_offset: 0
 routing:
   auth:
     mode: none


### PR DESCRIPTION
## Motivation

Part of the default Homarr board rework: Signal K Server takes the top-left corner now that Cockpit has moved to the top-right.

## Approach

In `apps/signalk-server/metadata.yaml`:
- `y_offset` 1 → 0 (now anchored at column 0, row 0; size unchanged at 2×2)

App version bumped 2.27.0-2 → 2.27.0-3 (per-PR app-level version bump for `apps/signalk-server/` changes).

## Coordination

One of four coordinated PRs adjusting the dashboard layout (cockpit-config, core-containers, marine signalk-server, homarr-container-adapter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)