### PR TITLE
fix: resolve marine app HALOS_DOMAIN from hostnames.conf canonical

### DIFF
--- a/apps/avnav/metadata.yaml
+++ b/apps/avnav/metadata.yaml
@@ -1,6 +1,6 @@
 name: AvNav
 app_id: avnav
-version: 20251028-16
+version: 20251028-17
 upstream_version: "20251028"
 description: Touch-optimized chart plotter for sailing and motor yachts
 long_description: |
@@ -34,6 +34,7 @@ debian_section: graphics
 architecture: all
 depends:
   - docker.io (>= 20.10) | docker-ce (>= 20.10)
+  - halos-core-containers
 web_ui:
   enabled: true
   path: /

--- a/apps/avnav/prestart.sh
+++ b/apps/avnav/prestart.sh
@@ -21,8 +21,21 @@ set +a
 HOSTNAME="$(hostname -s)"
 echo "HOSTNAME=$HOSTNAME" > "$RUNTIME_ENV"
 
-# Set HALOS_DOMAIN for Traefik routing
-HALOS_DOMAIN="${HOSTNAME}.local"
+# Resolve HALOS_DOMAIN from the canonical hostname in
+# /etc/halos/hostnames.conf via the shared loader (shipped by
+# halos-core-containers). Recomputed unconditionally: systemd loads the
+# previous runtime.env as an EnvironmentFile, so honoring an already-set
+# HALOS_DOMAIN would pin the first-resolved value forever. Fall back to
+# ${hostname}.local only when the loader is unavailable.
+LIB_HOSTNAMES="/usr/lib/halos-core-containers/lib-hostnames.sh"
+if [ -r "${LIB_HOSTNAMES}" ]; then
+    # shellcheck source=/dev/null
+    . "${LIB_HOSTNAMES}"
+    halos_load_hostnames
+    HALOS_DOMAIN="$(halos_canonical_hostname)"
+else
+    HALOS_DOMAIN="${HOSTNAME}.local"
+fi
 echo "HALOS_DOMAIN=$HALOS_DOMAIN" >> "$RUNTIME_ENV"
 
 # Compute Homarr URL

--- a/apps/grafana/metadata.yaml
+++ b/apps/grafana/metadata.yaml
@@ -1,6 +1,6 @@
 name: Grafana
 app_id: grafana
-version: 13.0.2-1
+version: 13.0.2-2
 upstream_version: 13.0.2
 description: Data visualization and monitoring platform
 long_description: |
@@ -29,6 +29,7 @@ debian_section: web
 architecture: all
 depends:
   - docker.io (>= 20.10) | docker-ce (>= 20.10)
+  - halos-core-containers
 recommends:
   - marine-influxdb-container
 web_ui:

--- a/apps/grafana/prestart.sh
+++ b/apps/grafana/prestart.sh
@@ -4,8 +4,19 @@
 
 set -e
 
-# Derive HALOS_DOMAIN from hostname if not set
-if [ -z "${HALOS_DOMAIN}" ]; then
+# Resolve HALOS_DOMAIN from the canonical hostname in
+# /etc/halos/hostnames.conf via the shared loader (shipped by
+# halos-core-containers). Recomputed unconditionally: systemd loads the
+# previous runtime.env as an EnvironmentFile, so honoring an already-set
+# HALOS_DOMAIN would pin the first-resolved value forever. Fall back to
+# ${hostname}.local only when the loader is unavailable.
+LIB_HOSTNAMES="/usr/lib/halos-core-containers/lib-hostnames.sh"
+if [ -r "${LIB_HOSTNAMES}" ]; then
+    # shellcheck source=/dev/null
+    . "${LIB_HOSTNAMES}"
+    halos_load_hostnames
+    HALOS_DOMAIN="$(halos_canonical_hostname)"
+else
     HALOS_DOMAIN="$(hostname -s).local"
 fi
 

--- a/apps/influxdb/metadata.yaml
+++ b/apps/influxdb/metadata.yaml
@@ -1,6 +1,6 @@
 name: InfluxDB
 app_id: influxdb
-version: 2.9.1-2
+version: 2.9.1-3
 upstream_version: 2.9.1
 description: Time-series database for marine data logging
 long_description: |
@@ -28,6 +28,7 @@ debian_section: net
 architecture: all
 depends:
   - docker.io (>= 20.10) | docker-ce (>= 20.10)
+  - halos-core-containers
 web_ui:
   enabled: true
   path: /

--- a/apps/influxdb/prestart.sh
+++ b/apps/influxdb/prestart.sh
@@ -18,9 +18,26 @@ set +a
 # Write standard runtime env vars
 mkdir -p "${RUN_DIR}"
 HOSTNAME="$(hostname -s)"
+
+# Resolve HALOS_DOMAIN from the canonical hostname in
+# /etc/halos/hostnames.conf via the shared loader (shipped by
+# halos-core-containers). Recomputed unconditionally: systemd loads the
+# previous runtime.env as an EnvironmentFile, so honoring an already-set
+# HALOS_DOMAIN would pin the first-resolved value forever. Fall back to
+# ${hostname}.local only when the loader is unavailable.
+LIB_HOSTNAMES="/usr/lib/halos-core-containers/lib-hostnames.sh"
+if [ -r "${LIB_HOSTNAMES}" ]; then
+    # shellcheck source=/dev/null
+    . "${LIB_HOSTNAMES}"
+    halos_load_hostnames
+    HALOS_DOMAIN="$(halos_canonical_hostname)"
+else
+    HALOS_DOMAIN="${HOSTNAME}.local"
+fi
+
 cat > "${RUNTIME_ENV}" << EOF
 HOSTNAME=${HOSTNAME}
-HALOS_DOMAIN=${HOSTNAME}.local
+HALOS_DOMAIN=${HALOS_DOMAIN}
 HOMARR_URL=http://${HOSTNAME}.local:8086/
 EOF
 

--- a/apps/signalk-server/metadata.yaml
+++ b/apps/signalk-server/metadata.yaml
@@ -1,6 +1,6 @@
 name: Signal K Server
 app_id: signalk-server
-version: 2.27.0-3
+version: 2.27.0-4
 upstream_version: 2.27.0
 description: Signal K server for marine data processing and routing
 long_description: |
@@ -30,6 +30,7 @@ architecture: all
 depends:
   - docker.io (>= 20.10) | docker-ce (>= 20.10)
   - python3-bcrypt
+  - halos-core-containers
 web_ui:
   enabled: true
   path: /

--- a/apps/signalk-server/prestart.sh
+++ b/apps/signalk-server/prestart.sh
@@ -4,8 +4,19 @@
 
 set -e
 
-# Derive HALOS_DOMAIN from hostname if not set
-if [ -z "${HALOS_DOMAIN}" ]; then
+# Resolve HALOS_DOMAIN from the canonical hostname in
+# /etc/halos/hostnames.conf via the shared loader (shipped by
+# halos-core-containers). Recomputed unconditionally: systemd loads the
+# previous runtime.env as an EnvironmentFile, so honoring an already-set
+# HALOS_DOMAIN would pin the first-resolved value forever. Fall back to
+# ${hostname}.local only when the loader is unavailable.
+LIB_HOSTNAMES="/usr/lib/halos-core-containers/lib-hostnames.sh"
+if [ -r "${LIB_HOSTNAMES}" ]; then
+    # shellcheck source=/dev/null
+    . "${LIB_HOSTNAMES}"
+    halos_load_hostnames
+    HALOS_DOMAIN="$(halos_canonical_hostname)"
+else
     HALOS_DOMAIN="$(hostname -s).local"
 fi
 


### PR DESCRIPTION
## Why

The four marine app prestarts (`avnav`, `grafana`, `influxdb`, `signalk-server`) derived `HALOS_DOMAIN` from `$(hostname -s).local` and never read `/etc/halos/hostnames.conf`. Their OIDC issuer, redirect, and self-referential root URLs pinned to the `.local` name regardless of the admin's canonical hostname — so on a device whose canonical is `<canonical-domain>` (VPN/DNS alias), SignalK and Grafana SSO redirected to `<device>.local`. Reordering `hostnames.conf` and rebooting did not help.

Homarr (in `halos-core-containers`) was unaffected because its prestart already sources the shared loader.

## Two compounding causes

1. **Prestarts never consulted `hostnames.conf`.** `halos-core-containers` ships the canonical-hostname loader at `/usr/lib/halos-core-containers/lib-hostnames.sh`; only its own prestart sourced it.
2. **`runtime.env` is loaded back as a systemd `EnvironmentFile`.** The unit lists `EnvironmentFiles=/run/container-apps/<app>/runtime.env`, so the *previous* run's `HALOS_DOMAIN` is already set when `ExecStartPre` runs prestart. A `[ -z HALOS_DOMAIN ]` guard would see the stale value and write it straight back — pinning the first-resolved value forever. This is why a reboot never cleared it.

## How

- Each prestart now sources `lib-hostnames.sh` and sets `HALOS_DOMAIN="$(halos_canonical_hostname)"` **unconditionally** (no `[ -z ]` guard), mirroring `halos-core-containers/prestart.sh`. The loader's own logic returns `${hostname}.local` for a missing/invalid config; a bare `hostname.local` fallback remains only for when the loader file itself is absent.
- Declare the `halos-core-containers` dependency that the sourcing (and the OIDC integration) requires.
- Bump each touched app's `metadata.yaml` revision (per-PR app-level version gate). `VERSION` untouched — mid-cycle.

## Verification

Patched the installed SignalK + Grafana prestarts on a live device (canonical `<canonical-domain>`) and restarted the services:

- `SIGNALK_OIDC_ISSUER=https://<canonical-domain>/sso`; redirect URI on `<canonical-domain>`
- `GF_AUTH_GENERIC_OAUTH_AUTH_URL=https://<canonical-domain>/...`; `GF_SERVER_ROOT_URL=https://<canonical-domain>:4432`
- Live SignalK OIDC login 302s to `https://<canonical-domain>/sso/api/oidc/authorization?...redirect_uri=https://<canonical-domain>/...` — no `<device>.local` in the chain
- `EXTERNALHOST=<canonical-domain>` (the `%.local` strip correctly no-ops on a non-`.local` fqdn)

`bash -n` + shellcheck clean on all four prestarts.

## Out of scope

- `.local`-pinned cross-app `HOMARR_URL` self-links in influxdb/avnav (non-OIDC; break under VPN-only access) — noted as a follow-up.
- `configure-container-routing`'s identical fallback (path-only routing, no longer drives OIDC).

Closes #177
