### PR TITLE
docs(agents): note the highest-level-wins version-bump rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ Individual apps in `apps/` have their own versions in `metadata.yaml`. These are
 **CI Enforcement**:
 
 - **App-level (per PR)**: PRs that change files in `apps/<app>/` must bump the `version` field in `apps/<app>/metadata.yaml`, or CI will fail.
-- **Repo-level (per release cycle)**: `VERSION` bumps are per release cycle, not per PR — CI fails only on the PR that opens a new cycle. This repo is a clean example: a single `VERSION` of `0.3.2` has shipped twelve `+N` prereleases. See the workspace `AGENTS.md` version-bump policy for the decision procedure.
+- **Repo-level (per release cycle)**: `VERSION` bumps are per release cycle, not per PR — CI fails only on the PR that opens a new cycle. This repo is a clean example: a single `VERSION` of `0.3.2` has shipped twelve `+N` prereleases. See the workspace `AGENTS.md` version-bump policy for the decision procedure — including the highest-level-wins rule: if a change at a higher semver level than the cycle-opening bump lands mid-cycle, re-bump `VERSION` up to that level once.
 
 ## What This Repository Contains
 


### PR DESCRIPTION
## Why

This repo's version-bump bullet defers to the workspace `AGENTS.md` for the decision procedure. That procedure is gaining a **highest-level-wins** clause: if a change at a higher semver level than the cycle-opening bump lands mid-cycle, re-bump `VERSION` up to that level once (a feature in a patch-opened cycle shouldn't ship under a patch number).

## What

Extends the deferral pointer to call out the highest-level-wins rule, so a reader here sees it without having to discover it only in the workspace policy.

## Scope

Companion to the canonical change in `halos-org/halos` (workspace `AGENTS.md`) and the first application in `halos-org/halos-core-containers` PR #195. Documentation only; no behavior change.