### PR TITLE
feat: inherit HALOS_DOMAIN in marine prestarts (#206 Unit 4)

### DIFF
--- a/apps/avnav/metadata.yaml
+++ b/apps/avnav/metadata.yaml
@@ -1,6 +1,6 @@
 name: AvNav
 app_id: avnav
-version: 20251028-16
+version: 20251028-17
 upstream_version: "20251028"
 description: Touch-optimized chart plotter for sailing and motor yachts
 long_description: |

--- a/apps/avnav/prestart.sh
+++ b/apps/avnav/prestart.sh
@@ -21,12 +21,9 @@ set +a
 HOSTNAME="$(hostname -s)"
 echo "HOSTNAME=$HOSTNAME" > "$RUNTIME_ENV"
 
-# Set HALOS_DOMAIN for Traefik routing
-HALOS_DOMAIN="${HOSTNAME}.local"
-echo "HALOS_DOMAIN=$HALOS_DOMAIN" >> "$RUNTIME_ENV"
-
-# Compute Homarr URL
-HOMARR_URL="http://${HOSTNAME}.local:8080"
+# Compute Homarr URL from the inherited HALOS_DOMAIN (published by
+# halos-resolve-domain.service via /run/halos/domain.env).
+HOMARR_URL="http://${HALOS_DOMAIN}:8080"
 echo "HOMARR_URL=$HOMARR_URL" >> "$RUNTIME_ENV"
 
 # -- Signal K handler: use host.docker.internal instead of localhost --

--- a/apps/grafana/metadata.yaml
+++ b/apps/grafana/metadata.yaml
@@ -1,6 +1,6 @@
 name: Grafana
 app_id: grafana
-version: 13.0.2-1
+version: 13.0.2-2
 upstream_version: 13.0.2
 description: Data visualization and monitoring platform
 long_description: |

--- a/apps/grafana/prestart.sh
+++ b/apps/grafana/prestart.sh
@@ -4,11 +4,8 @@
 
 set -e
 
-# Derive HALOS_DOMAIN from hostname if not set
-if [ -z "${HALOS_DOMAIN}" ]; then
-    HALOS_DOMAIN="$(hostname -s).local"
-fi
-
+# HALOS_DOMAIN is inherited from /run/halos/domain.env (published once by
+# halos-resolve-domain.service and loaded by the generated unit).
 echo "Grafana prestart: domain=${HALOS_DOMAIN}"
 
 # Generate OIDC client secret if it doesn't exist
@@ -31,11 +28,10 @@ if [ -z "${EXTERNAL_PORT}" ]; then
     exit 1
 fi
 
-# Write runtime env file with expanded HALOS_DOMAIN
+# Write runtime env file
 RUNTIME_ENV_DIR="/run/container-apps/marine-grafana-container"
 mkdir -p "${RUNTIME_ENV_DIR}"
 cat > "${RUNTIME_ENV_DIR}/runtime.env" << EOF
-HALOS_DOMAIN=${HALOS_DOMAIN}
 GRAFANA_OIDC_CLIENT_SECRET=$(cat "${OIDC_SECRET_FILE}")
 HALOS_EXTERNAL_PORT=${EXTERNAL_PORT}
 EOF

--- a/apps/influxdb/metadata.yaml
+++ b/apps/influxdb/metadata.yaml
@@ -1,6 +1,6 @@
 name: InfluxDB
 app_id: influxdb
-version: 2.9.1-2
+version: 2.9.1-3
 upstream_version: 2.9.1
 description: Time-series database for marine data logging
 long_description: |

--- a/apps/influxdb/prestart.sh
+++ b/apps/influxdb/prestart.sh
@@ -18,10 +18,11 @@ set +a
 # Write standard runtime env vars
 mkdir -p "${RUN_DIR}"
 HOSTNAME="$(hostname -s)"
+# HALOS_DOMAIN is inherited from /run/halos/domain.env (published by
+# halos-resolve-domain.service); HOMARR_URL is built from it.
 cat > "${RUNTIME_ENV}" << EOF
 HOSTNAME=${HOSTNAME}
-HALOS_DOMAIN=${HOSTNAME}.local
-HOMARR_URL=http://${HOSTNAME}.local:8086/
+HOMARR_URL=http://${HALOS_DOMAIN}:8086/
 EOF
 
 # --- Token generation ---

--- a/apps/signalk-server/metadata.yaml
+++ b/apps/signalk-server/metadata.yaml
@@ -1,6 +1,6 @@
 name: Signal K Server
 app_id: signalk-server
-version: 2.27.0-3
+version: 2.27.0-4
 upstream_version: 2.27.0
 description: Signal K server for marine data processing and routing
 long_description: |

--- a/apps/signalk-server/prestart.sh
+++ b/apps/signalk-server/prestart.sh
@@ -4,10 +4,8 @@
 
 set -e
 
-# Derive HALOS_DOMAIN from hostname if not set
-if [ -z "${HALOS_DOMAIN}" ]; then
-    HALOS_DOMAIN="$(hostname -s).local"
-fi
+# HALOS_DOMAIN is inherited from /run/halos/domain.env (published once by
+# halos-resolve-domain.service and loaded by the generated unit).
 
 SIGNALK_DATA="${CONTAINER_DATA_ROOT}/data"
 SECURITY_FILE="${SIGNALK_DATA}/security.json"
@@ -66,9 +64,9 @@ if [ ! -f "${OIDC_SECRET_FILE}" ]; then
     echo "OIDC client secret stored in ${OIDC_SECRET_FILE}"
 fi
 
-# Write runtime env file for systemd to load
-# HALOS_DOMAIN is needed for docker-compose label substitution
-# OIDC settings expand HALOS_DOMAIN since systemd EnvironmentFile doesn't
+# Write runtime env file for systemd to load. The OIDC/EXTERNALHOST values
+# below expand the inherited HALOS_DOMAIN at prestart time because systemd
+# EnvironmentFile does not expand variables.
 RUNTIME_ENV_DIR="/run/container-apps/marine-signalk-server-container"
 mkdir -p "${RUNTIME_ENV_DIR}"
 
@@ -81,7 +79,6 @@ fi
 
 # EXTERNALHOST strips .local suffix — Signal K's mDNS library (dnssd) appends it
 cat > "${RUNTIME_ENV_DIR}/runtime.env" << EOF
-HALOS_DOMAIN=${HALOS_DOMAIN}
 EXTERNALHOST=${HALOS_DOMAIN%.local}
 EXTERNALPORT=${EXTERNAL_PORT:-443}
 # Requires upstream EXTERNALSSL support: https://github.com/SignalK/signalk-server/pull/2484


### PR DESCRIPTION
## What

Unit 4 of container-packaging-tools#206. The four marine apps (avnav, grafana, influxdb, signalk-server) ship custom prestarts that resolved `HALOS_DOMAIN` themselves and hardcoded `${HOSTNAME}.local`, pinning OIDC issuer/redirect URLs to `.local` and ignoring admin-managed `hostnames.conf` — the #177 symptom.

## How

With container-packaging-tools 0.7.0 and halos-core-containers 0.5.0 now on stable, the always-generated systemd unit loads `HALOS_DOMAIN` from the `halos-resolve-domain` producer via `EnvironmentFile=-/run/halos/domain.env` (ordered after the producer). The prestarts now **inherit** that value instead of resolving it:

- **avnav, influxdb** — `HOMARR_URL` built from `${HALOS_DOMAIN}`, not `${HOSTNAME}.local`.
- **grafana, signalk-server** — drop the `[ -z HALOS_DOMAIN ]` self-resolve guard (it pinned the first-resolved value forever); OIDC issuer/redirect and `EXTERNALHOST=${HALOS_DOMAIN%.local}` expand the inherited value at prestart time.
- None write `HALOS_DOMAIN` back to `runtime.env`, removing the stale-pin feedback loop. The generator injects `Depends: halos-core-containers (>= 0.5.0)`, so no per-app depend is added here.
- Per-app metadata versions bumped (revision only — packaging change, not an image change).

This is the centralized-inheritance fix from #206, superseding the self-resolve band-aid originally sketched in #177 (closed PR #178).

## Verification

- `bash -n` + shellcheck clean on all four prestarts; 26 marine tests pass.
- Generator integration (the unit gains `EnvironmentFile=domain.env` + ordering + `Depends`) is covered by container-packaging-tools' own test suite for `has_routing` apps; all four marine apps are routing/web_ui.
- `halos_canonical_hostname` always returns non-empty (DNS entry or `${hostname}.local` fallback), so the inherited value is populated on the happy path.
- Reviewed by correctness + reliability + security personas — no blocking findings (security: zero). The only theme is the empty-`HALOS_DOMAIN` degradation if the producer is absent, which is the explicitly-accepted #206 D6 decision (recoverable, fails closed, apt-gated by the `>= 0.5.0` dependency).
- Pending: deploy + OIDC flow verification on a device with a non-`.local` canonical.

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)
