### PR TITLE
feat: migrate marine apps to composable prestart + declarative OIDC

### DIFF
--- a/apps/avnav/default-data/data/avnav_server.xml
+++ b/apps/avnav/default-data/data/avnav_server.xml
@@ -1,0 +1,3 @@
+<AVNServer>
+  <AVNSignalKHandler host="host.docker.internal"/>
+</AVNServer>

--- a/apps/avnav/metadata.yaml
+++ b/apps/avnav/metadata.yaml
@@ -1,6 +1,6 @@
 name: AvNav
 app_id: avnav
-version: 20251028-17
+version: 20251028-18
 upstream_version: "20251028"
 description: Touch-optimized chart plotter for sailing and motor yachts
 long_description: |

--- a/apps/avnav/prestart.sh
+++ b/apps/avnav/prestart.sh
@@ -1,54 +1,19 @@
 #!/bin/bash
-# AvNav prestart script
-# Patches Signal K handler to connect via host.docker.internal
-# (Signal K runs on host network; AvNav runs on bridge network)
-
-set -e
-
-# -- Standard boilerplate (replaces auto-generated prestart) --
-
-# Create runtime directory
-RUNTIME_ENV="/run/container-apps/marine-avnav-container/runtime.env"
-mkdir -p "$(dirname "$RUNTIME_ENV")"
-
-# Load config values from env files
-set -a
-[ -f "/etc/container-apps/marine-avnav-container/env.defaults" ] && . "/etc/container-apps/marine-avnav-container/env.defaults"
-[ -f "/etc/container-apps/marine-avnav-container/env" ] && . "/etc/container-apps/marine-avnav-container/env"
-set +a
-
-# Set hostname
-HOSTNAME="$(hostname -s)"
-echo "HOSTNAME=$HOSTNAME" > "$RUNTIME_ENV"
-
-# Compute Homarr URL from the inherited HALOS_DOMAIN (published by
-# halos-resolve-domain.service via /run/halos/domain.env).
-HOMARR_URL="http://${HALOS_DOMAIN}:8080"
-echo "HOMARR_URL=$HOMARR_URL" >> "$RUNTIME_ENV"
-
-# -- Signal K handler: use host.docker.internal instead of localhost --
+# AvNav app-prestart hook (sourced by the generated framework prestart).
+# Keeps AvNav's Signal K handler pointed at host.docker.internal: Signal K
+# runs on the host network while AvNav runs on a bridge network. The seed
+# avnav_server.xml ships via default-data/; this hook only corrects the
+# handler host if AvNav rewrites it back to localhost.
 
 AVNAV_CONFIG="${CONTAINER_DATA_ROOT}/data/avnav_server.xml"
 
 if [ ! -f "${AVNAV_CONFIG}" ]; then
-    # First run: create seed config with correct Signal K host.
-    # AvNav auto-instantiates all other handlers with defaults.
-    echo "AvNav prestart: creating seed avnav_server.xml..."
-    mkdir -p "$(dirname "${AVNAV_CONFIG}")"
-    chown 1000:1000 "$(dirname "${AVNAV_CONFIG}")"
-    cat > "${AVNAV_CONFIG}" << 'EOF'
-<AVNServer>
-  <AVNSignalKHandler host="host.docker.internal"/>
-</AVNServer>
-EOF
-    chown 1000:1000 "${AVNAV_CONFIG}"
+    echo "AvNav prestart: ${AVNAV_CONFIG} not present yet, skipping host patch."
 elif grep -q 'AVNSignalKHandler[^>]*host="localhost"' "${AVNAV_CONFIG}"; then
-    # Default host="localhost": patch to host.docker.internal
     echo "AvNav prestart: patching Signal K host to host.docker.internal..."
     sed -i 's/\(AVNSignalKHandler[^>]*\)host="localhost"/\1host="host.docker.internal"/' "${AVNAV_CONFIG}"
 elif grep -q 'AVNSignalKHandler' "${AVNAV_CONFIG}" && \
      ! grep -q 'AVNSignalKHandler[^>]*host=' "${AVNAV_CONFIG}"; then
-    # Handler exists but no explicit host attribute (implicit localhost default)
     echo "AvNav prestart: adding Signal K host attribute..."
     sed -i 's/\(<AVNSignalKHandler\)\([^>]*>\)/\1 host="host.docker.internal"\2/' "${AVNAV_CONFIG}"
 else

--- a/apps/grafana/metadata.yaml
+++ b/apps/grafana/metadata.yaml
@@ -1,6 +1,6 @@
 name: Grafana
 app_id: grafana
-version: 13.0.2-2
+version: 13.0.2-3
 upstream_version: 13.0.2
 description: Data visualization and monitoring platform
 long_description: |
@@ -39,10 +39,22 @@ web_ui:
   visible: true
 routing:
   auth:
-    mode: none  # Grafana handles OAuth natively via prestart.sh OIDC registration
+    # Grafana authenticates users itself via Authelia OIDC (native OAuth), so
+    # there is no Traefik edge gate; mode: oidc wires the Authelia client
+    # scaffolding (secret provisioning, snippet, unit ordering) declaratively.
+    mode: oidc
+    oidc:
+      client_name: Grafana
+      token_endpoint_auth_method: client_secret_basic
+      scopes: [openid, profile, email, groups]
+      consent_mode: implicit
+      redirect:
+        style: port  # Grafana derives its redirect from the external HTTPS port
+        path: /login/generic_oauth
+      env:
+        GRAFANA_OIDC_CLIENT_SECRET: secret
+        HALOS_EXTERNAL_PORT: external_port
 layout:
   priority: 50
   width: 2
   height: 2
-# OIDC configuration is set via prestart.sh and runtime.env
-# OAuth provides authentication via Authelia SSO

--- a/apps/grafana/prestart.sh
+++ b/apps/grafana/prestart.sh
@@ -1,98 +1,42 @@
 #!/bin/bash
-# Grafana prestart script
-# Sets up OIDC authentication with Authelia
+# Grafana app-prestart hook (sourced by the generated framework prestart).
+# OIDC is declarative now (routing.auth.mode: oidc): the framework provisions
+# the client secret, resolves the external port, writes the Authelia snippet,
+# and appends GRAFANA_OIDC_CLIENT_SECRET + HALOS_EXTERNAL_PORT to runtime.env.
+# This hook only covers the residual, app-specific steps.
 
-set -e
-
-# HALOS_DOMAIN is inherited from /run/halos/domain.env (published once by
-# halos-resolve-domain.service and loaded by the generated unit).
-echo "Grafana prestart: domain=${HALOS_DOMAIN}"
-
-# Generate OIDC client secret if it doesn't exist
-OIDC_SECRET_FILE="${CONTAINER_DATA_ROOT}/oidc-secret"
-if [ ! -f "${OIDC_SECRET_FILE}" ]; then
-    echo "Generating OIDC client secret..."
-    openssl rand -hex 32 > "${OIDC_SECRET_FILE}"
-    chmod 600 "${OIDC_SECRET_FILE}"
+# The framework computes HOMARR_URL from web_ui.port (3000), but Grafana is
+# reached through Traefik on its dedicated external HTTPS port, not the internal
+# container port. Override with the port-based URL; the later value wins when the
+# unit loads runtime.env as an EnvironmentFile.
+GRAFANA_EXTERNAL_PORT="$(grep '^grafana=' /etc/halos/port-registry 2>/dev/null | cut -d= -f2)"
+if [ -n "${GRAFANA_EXTERNAL_PORT}" ]; then
+    echo "HOMARR_URL=https://${HALOS_DOMAIN}:${GRAFANA_EXTERNAL_PORT}" >> "$RUNTIME_ENV"
 fi
 
-# Read external port from port registry (assigned by configure-container-routing)
-EXTERNAL_PORT=""
-PORT_REGISTRY="/etc/halos/port-registry"
-if [ -f "${PORT_REGISTRY}" ]; then
-    EXTERNAL_PORT=$(grep "^grafana=" "${PORT_REGISTRY}" 2>/dev/null | cut -d= -f2)
-fi
-
-if [ -z "${EXTERNAL_PORT}" ]; then
-    echo "ERROR: Grafana external port not found in ${PORT_REGISTRY}"
-    exit 1
-fi
-
-# Write runtime env file
-RUNTIME_ENV_DIR="/run/container-apps/marine-grafana-container"
-mkdir -p "${RUNTIME_ENV_DIR}"
-cat > "${RUNTIME_ENV_DIR}/runtime.env" << EOF
-GRAFANA_OIDC_CLIENT_SECRET=$(cat "${OIDC_SECRET_FILE}")
-HALOS_EXTERNAL_PORT=${EXTERNAL_PORT}
-EOF
-chmod 600 "${RUNTIME_ENV_DIR}/runtime.env"
-
-# Install OIDC client snippet for Authelia
-# Redirect URI uses the port-based URL that Grafana derives from GF_SERVER_ROOT_URL
-OIDC_CLIENTS_DIR="/etc/halos/oidc-clients.d"
-OIDC_CLIENT_SNIPPET="${OIDC_CLIENTS_DIR}/grafana.yml"
-mkdir -p "${OIDC_CLIENTS_DIR}"
-cat > "${OIDC_CLIENT_SNIPPET}" << EOF
-# Grafana OIDC Client Snippet
-# Installed by marine-grafana-container prestart.sh
-#
-# \${HALOS_DOMAIN} is preserved as a literal placeholder (escaped \\\$ in
-# the unquoted heredoc). halos-core-containers' OIDC merger expands it
-# to one redirect_uri per configured DNS hostname at merge time.
-# \${EXTERNAL_PORT} is the prestart-resolved port and substitutes at
-# write time.
-
-client_id: grafana
-client_name: Grafana
-client_secret_file: /var/lib/container-apps/marine-grafana-container/data/oidc-secret
-redirect_uris:
-  - 'https://\${HALOS_DOMAIN}:${EXTERNAL_PORT}/login/generic_oauth'
-scopes: [openid, profile, email, groups]
-consent_mode: implicit
-token_endpoint_auth_method: client_secret_basic
-EOF
-
-# Ensure data directory exists and has correct ownership (Grafana runs as UID 472)
-# Note: Only chown the data subdir, not the oidc-secret which should remain root-owned
+# Grafana runs as UID 472 and writes its database under the data volume.
 mkdir -p "${CONTAINER_DATA_ROOT}/data"
 chown -R 472:472 "${CONTAINER_DATA_ROOT}/data"
 
 # --- InfluxDB datasource provisioning ---
-
+# Provisioning is conditional on InfluxDB (Grafana only recommends it), so the
+# datasource is copied in when InfluxDB + its token are present and removed
+# otherwise — it is not unconditional static seed. Grafana expands
+# $__env{INFLUXDB_TOKEN} (supplied via runtime.env) at startup.
 INFLUXDB_ENV="/etc/container-apps/marine-influxdb-container/env"
 PROVISIONING_DIR="${CONTAINER_DATA_ROOT}/provisioning/datasources"
 DATASOURCE_SRC="/var/lib/container-apps/marine-grafana-container/assets/influxdb-datasource.yaml"
 DATASOURCE_DST="${PROVISIONING_DIR}/influxdb.yaml"
-
 mkdir -p "${PROVISIONING_DIR}"
-
 if [ -f "${INFLUXDB_ENV}" ]; then
-    # Extract only the token — avoid sourcing the entire file
     INFLUXDB_ADMIN_TOKEN=$(grep '^INFLUXDB_ADMIN_TOKEN=' "${INFLUXDB_ENV}" | cut -d= -f2-)
-
     if [ -n "${INFLUXDB_ADMIN_TOKEN}" ] && [ -f "${DATASOURCE_SRC}" ]; then
-        echo "InfluxDB detected -- provisioning datasource"
         cp "${DATASOURCE_SRC}" "${DATASOURCE_DST}"
-        # Pass token to Grafana container via runtime.env
-        echo "INFLUXDB_TOKEN=${INFLUXDB_ADMIN_TOKEN}" >> "${RUNTIME_ENV_DIR}/runtime.env"
+        echo "INFLUXDB_TOKEN=${INFLUXDB_ADMIN_TOKEN}" >> "$RUNTIME_ENV"
     else
-        [ ! -f "${DATASOURCE_SRC}" ] && echo "WARNING: InfluxDB datasource template not found at ${DATASOURCE_SRC}"
         rm -f "${DATASOURCE_DST}"
     fi
 else
     rm -f "${DATASOURCE_DST}"
 fi
-
 chown -R 472:472 "${PROVISIONING_DIR}"
-
-echo "Grafana prestart complete"

--- a/apps/influxdb/metadata.yaml
+++ b/apps/influxdb/metadata.yaml
@@ -1,6 +1,6 @@
 name: InfluxDB
 app_id: influxdb
-version: 2.9.1-3
+version: 2.9.1-4
 upstream_version: 2.9.1
 description: Time-series database for marine data logging
 long_description: |

--- a/apps/influxdb/prestart.sh
+++ b/apps/influxdb/prestart.sh
@@ -1,29 +1,11 @@
 #!/bin/bash
-# Prestart script for marine-influxdb-container
-# Handles runtime env setup and admin password sync after first-time init.
-set -e
+# InfluxDB app-prestart hook (sourced by the generated framework prestart).
+# Runtime dir, env sourcing, and HOMARR_URL are provided by the framework;
+# this hook only rotates the admin token and syncs the admin password.
 
 PACKAGE_NAME="marine-influxdb-container"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ETC_DIR="/etc/container-apps/${PACKAGE_NAME}"
-RUN_DIR="/run/container-apps/${PACKAGE_NAME}"
-RUNTIME_ENV="${RUN_DIR}/runtime.env"
-
-# Load config values from env files
-set -a
-[ -f "${ETC_DIR}/env.defaults" ] && . "${ETC_DIR}/env.defaults"
-[ -f "${ETC_DIR}/env" ] && . "${ETC_DIR}/env"
-set +a
-
-# Write standard runtime env vars
-mkdir -p "${RUN_DIR}"
-HOSTNAME="$(hostname -s)"
-# HALOS_DOMAIN is inherited from /run/halos/domain.env (published by
-# halos-resolve-domain.service); HOMARR_URL is built from it.
-cat > "${RUNTIME_ENV}" << EOF
-HOSTNAME=${HOSTNAME}
-HOMARR_URL=http://${HALOS_DOMAIN}:8086/
-EOF
 
 # --- Token generation ---
 

--- a/apps/signalk-server/metadata.yaml
+++ b/apps/signalk-server/metadata.yaml
@@ -1,6 +1,6 @@
 name: Signal K Server
 app_id: signalk-server
-version: 2.27.0-4
+version: 2.27.0-5
 upstream_version: 2.27.0
 description: Signal K server for marine data processing and routing
 long_description: |
@@ -43,16 +43,31 @@ layout:
   x_offset: 0
   y_offset: 0
 routing:
-  auth:
-    mode: none
   host_port: 3000
+  auth:
+    # Signal K authenticates users itself via Authelia OIDC (native OAuth), so
+    # there is no Traefik edge gate; mode: oidc wires the Authelia client
+    # scaffolding declaratively. The registered client id is "signalk" (the
+    # app_id is signalk-server), and the redirect is path-based.
+    mode: oidc
+    oidc:
+      client_id: signalk
+      client_name: "Signal K Server"
+      token_endpoint_auth_method: client_secret_post
+      scopes: [openid, profile, email, groups]
+      consent_mode: implicit
+      redirect:
+        style: path
+        path: /signalk-server/signalk/v1/auth/oidc/callback
+      env:
+        SIGNALK_OIDC_CLIENT_SECRET: secret
+        SIGNALK_OIDC_ISSUER: issuer
+        SIGNALK_OIDC_REDIRECT_URI: redirect
 default_config:
-  # OIDC Configuration - enabled by default for SSO integration
+  # OIDC: the dynamic values (client secret, issuer, redirect) are supplied at
+  # runtime via the generated runtime.env; only the static settings live here.
   SIGNALK_OIDC_ENABLED: "true"
-  SIGNALK_OIDC_ISSUER: "https://${HALOS_DOMAIN}/sso"
   SIGNALK_OIDC_CLIENT_ID: "signalk"
-  SIGNALK_OIDC_CLIENT_SECRET: ""
-  SIGNALK_OIDC_REDIRECT_URI: "https://${HALOS_DOMAIN}/signalk-server/signalk/v1/auth/oidc/callback"
   SIGNALK_OIDC_SCOPE: "openid email profile groups"
   SIGNALK_OIDC_PROVIDER_NAME: "HaLOS SSO"
   SIGNALK_OIDC_DEFAULT_PERMISSION: "readonly"

--- a/apps/signalk-server/prestart.sh
+++ b/apps/signalk-server/prestart.sh
@@ -1,11 +1,10 @@
 #!/bin/bash
-# Signal K Server prestart script
-# Creates security.json with default admin user if not exists
-
-set -e
-
-# HALOS_DOMAIN is inherited from /run/halos/domain.env (published once by
-# halos-resolve-domain.service and loaded by the generated unit).
+# Signal K Server app-prestart hook (sourced by the generated framework prestart).
+# OIDC is declarative now (routing.auth.mode: oidc): the framework provisions the
+# client secret, writes the Authelia snippet, and appends SIGNALK_OIDC_CLIENT_SECRET
+# /_ISSUER/_REDIRECT_URI to runtime.env. This hook keeps the Signal K-specific
+# steps: the security.json bootstrap, external-URL advertising, and the InfluxDB
+# logging plugin.
 
 SIGNALK_DATA="${CONTAINER_DATA_ROOT}/data"
 SECURITY_FILE="${SIGNALK_DATA}/security.json"
@@ -55,60 +54,17 @@ EOF
     chmod 600 "${CONTAINER_DATA_ROOT}/admin-password"
 fi
 
-# Generate OIDC client secret if it doesn't exist
-OIDC_SECRET_FILE="${CONTAINER_DATA_ROOT}/oidc-secret"
-if [ ! -f "${OIDC_SECRET_FILE}" ]; then
-    echo "Generating OIDC client secret..."
-    openssl rand -hex 32 > "${OIDC_SECRET_FILE}"
-    chmod 600 "${OIDC_SECRET_FILE}"
-    echo "OIDC client secret stored in ${OIDC_SECRET_FILE}"
-fi
-
-# Write runtime env file for systemd to load. The OIDC/EXTERNALHOST values
-# below expand the inherited HALOS_DOMAIN at prestart time because systemd
-# EnvironmentFile does not expand variables.
-RUNTIME_ENV_DIR="/run/container-apps/marine-signalk-server-container"
-mkdir -p "${RUNTIME_ENV_DIR}"
-
-# Read external port from port registry (assigned by configure-container-routing)
-EXTERNAL_PORT=""
-PORT_REGISTRY="/etc/halos/port-registry"
-if [ -f "${PORT_REGISTRY}" ]; then
-    EXTERNAL_PORT=$(grep "^signalk-server=" "${PORT_REGISTRY}" 2>/dev/null | cut -d= -f2)
-fi
-
-# EXTERNALHOST strips .local suffix — Signal K's mDNS library (dnssd) appends it
-cat > "${RUNTIME_ENV_DIR}/runtime.env" << EOF
-EXTERNALHOST=${HALOS_DOMAIN%.local}
-EXTERNALPORT=${EXTERNAL_PORT:-443}
-# Requires upstream EXTERNALSSL support: https://github.com/SignalK/signalk-server/pull/2484
-EXTERNALSSL=1
-SIGNALK_OIDC_CLIENT_SECRET=$(cat "${OIDC_SECRET_FILE}")
-SIGNALK_OIDC_ISSUER=https://${HALOS_DOMAIN}/sso
-SIGNALK_OIDC_REDIRECT_URI=https://${HALOS_DOMAIN}/signalk-server/signalk/v1/auth/oidc/callback
-EOF
-chmod 600 "${RUNTIME_ENV_DIR}/runtime.env"
-
-# Install OIDC client snippet for Authelia
-# Always written (not guarded) so redirect URIs stay current across upgrades
-OIDC_CLIENTS_DIR="/etc/halos/oidc-clients.d"
-OIDC_CLIENT_SNIPPET="${OIDC_CLIENTS_DIR}/signalk.yml"
-mkdir -p "${OIDC_CLIENTS_DIR}"
-cat > "${OIDC_CLIENT_SNIPPET}" << 'EOF'
-# Signal K OIDC Client Snippet
-# Installed by marine-signalk-server-container prestart.sh
-# Authelia's prestart script merges all snippets into oidc-clients.yml
-# Redirect URI uses path redirect (/signalk-server/) which 302s to the port URL
-
-client_id: signalk
-client_name: Signal K Server
-client_secret_file: /var/lib/container-apps/marine-signalk-server-container/data/oidc-secret
-redirect_uris:
-  - 'https://${HALOS_DOMAIN}/signalk-server/signalk/v1/auth/oidc/callback'
-scopes: [openid, profile, email, groups]
-consent_mode: implicit
-token_endpoint_auth_method: client_secret_post
-EOF
+# Signal K advertises its external URL via mDNS from these. EXTERNALHOST strips
+# the .local suffix that Signal K's dnssd library re-appends; the external port
+# comes from the routing registry, defaulting to the HTTPS port. Appended to the
+# framework-owned runtime.env (the OIDC vars are written there by the framework).
+EXTERNAL_PORT="$(grep '^signalk-server=' /etc/halos/port-registry 2>/dev/null | cut -d= -f2)"
+{
+    echo "EXTERNALHOST=${HALOS_DOMAIN%.local}"
+    echo "EXTERNALPORT=${EXTERNAL_PORT:-443}"
+    # Requires upstream EXTERNALSSL support: https://github.com/SignalK/signalk-server/pull/2484
+    echo "EXTERNALSSL=1"
+} >> "$RUNTIME_ENV"
 
 # --- InfluxDB plugin provisioning ---
 

--- a/tools/build-all.sh
+++ b/tools/build-all.sh
@@ -33,9 +33,11 @@ if command -v uvx >/dev/null 2>&1; then
     echo ""
     echo "=== Building container app packages ==="
 
-    # Determine tools source: local path, git ref, or default
+    # Determine tools source: local path, git ref, or pinned default.
+    # The apps require the composable-prestart + declarative-OIDC capabilities,
+    # so the default is pinned to a release tag rather than tracking main.
     TOOLS_PATH="${CONTAINER_TOOLS_PATH:-}"
-    TOOLS_REF="${CONTAINER_TOOLS_REF:-}"
+    TOOLS_REF="${CONTAINER_TOOLS_REF:-v0.8.0+3}"
     if [ -n "$TOOLS_PATH" ]; then
         TOOLS_SOURCE="$TOOLS_PATH"
         echo "Using local container-packaging-tools from: $TOOLS_PATH"


### PR DESCRIPTION
## Motivation

The four custom-prestart marine apps (avnav, influxdb, grafana, signalk) each
hand-rolled framework boilerplate, and grafana/signalk additionally hand-rolled
the entire OIDC lifecycle — the duplication that shipped the `HALOS_DOMAIN` bug.
container-packaging-tools `v0.8.0+3` ships the composable-prestart hook and
declarative OIDC; this migrates all four onto it in one coordinated window
(the repo builds every app under a single `CONTAINER_TOOLS_REF`).

## Approach

- **Pin** `CONTAINER_TOOLS_REF` default to `v0.8.0+3` (was tracking `main`).
- **avnav / influxdb** (composable prestart): slim each `prestart.sh` to the
  residual `app-prestart.sh` hook; the generated framework prestart owns
  `runtime.env` (created mode 600), env sourcing, and `HOMARR_URL`. avnav's
  seed `avnav_server.xml` moves to `default-data/`. influxdb's truncating
  `cat > runtime.env` is gone (the framework owns the file; the append-only
  contract holds).
- **grafana / signalk** (declarative OIDC): `routing.auth.mode: oidc` +
  `routing.auth.oidc`. postinst provisions the client secret once; the
  generated prestart writes the Authelia snippet and the OIDC `runtime.env`
  vars. The hooks keep only app-specific residue (grafana's conditional
  InfluxDB datasource provisioning from `assets/` + HOMARR_URL override;
  signalk's security.json bootstrap, `EXTERNAL*` advertising, InfluxDB plugin).

## Two notes for review

- **grafana `HOMARR_URL`**: the framework computes it from `web_ui.port` (3000),
  but grafana is reached via Traefik on its external HTTPS port, not the
  unpublished internal port. The hook overrides `HOMARR_URL` to
  `https://${HALOS_DOMAIN}:${external_port}` (last value wins in the unit's
  EnvironmentFile). Longer term this is a framework gap for port-routed apps
  (filed as #183 — it also affects influxdb/avnav tiles, pre-existing).
- **signalk #157 (red dot)**: signalk uses host networking and listens on port
  3000, so the framework's `http://${HALOS_DOMAIN}:3000` is directly reachable.
  Today signalk writes no `HOMARR_URL` (empty tile link), so uniform
  `HOMARR_URL` should fix the red dot — confirmed reachable (200) on-device.

## Verification

- All four `metadata.yaml` validate; generated grafana/signalk prestarts carry
  the correct OIDC section; all 6 packages build clean in the Docker builder.
- Package contents confirmed: framework `prestart.sh` + `app-prestart.sh` hook
  both present and sibling to `docker-compose.yml`; default-data placed right.
- **Device (halosdev.local)**: validated — append contract holds; grafana's
  `homarr.url` label resolves to the overridden `https://…:4432`; avnav
  first-boot seed + `host.docker.internal` patch applied; OIDC handshake +
  JAUTHENTICATION cookie + SSO pass on the canonical host. See the validation
  comment for the full table and pre-existing caveats.

Executes Plan A Unit 3 (halos-org/container-packaging-tools#207) and
Plan B Unit 5 (halos-org/container-packaging-tools#211).

Follow-ups filed: #182 (pre-existing signalk secret chown), #183 (pre-existing
routed-app HOMARR_URL gap).
