### PR TITLE
fix(avnav): decode SignalK data and AIS in seed config

### DIFF
--- a/apps/avnav/default-data/data/avnav_server.xml
+++ b/apps/avnav/default-data/data/avnav_server.xml
@@ -1,3 +1,3 @@
 <AVNServer>
-  <AVNSignalKHandler host="host.docker.internal"/>
+  <AVNSignalKHandler host="host.docker.internal" decodeData="true" fetchAis="true"/>
 </AVNServer>

--- a/apps/avnav/metadata.yaml
+++ b/apps/avnav/metadata.yaml
@@ -1,6 +1,6 @@
 name: AvNav
 app_id: avnav
-version: 20251028-18
+version: 20251028-19
 upstream_version: "20251028"
 description: Touch-optimized chart plotter for sailing and motor yachts
 long_description: |


### PR DESCRIPTION
## Why

A fresh AvNav install in HaLOS connects to SignalK (the seed config points the
handler at `host.docker.internal`), but the default navigation view stays empty
and no AIS targets appear. The handler is connected but inert.

Root cause: AvNav's `AVNSignalKHandler` defaults `decodeData` and `fetchAis` to
`False` (`signalkhandler.py`), so it registers the SignalK source without
translating any values into AvNav's data model. Users have to toggle both by
hand in the UI — confirmed on a device, where flipping `decodeData` made data
appear.

## What

Enable both flags in the seed `avnav_server.xml`. In HaLOS, SignalK is the data
hub and AvNav is a downstream consumer, so decoding SignalK data and fetching
AIS is the correct default — there's no direct NMEA source to double up with.

```diff
-  <AVNSignalKHandler host="host.docker.internal"/>
+  <AVNSignalKHandler host="host.docker.internal" decodeData="true" fetchAis="true"/>
```

Lowercase `"true"` is parsed correctly — `avnav_util.py` compares
`flagString.lower() == 'true'`.

## Versioning

Per-app bump only: `apps/avnav/metadata.yaml` `20251028-18 → -19`. No repo
`VERSION` bump — the change is confined to `apps/`, which the repo-level
version-bump check excludes.

## Scope

Only affects fresh installs / re-seeded data dirs; existing devices keep their
current config. Does not retroactively fix already-installed devices.