### PR TITLE
fix(signalk-server): grant adm GID for halpid 5.1.0 socket

### DIFF
--- a/apps/signalk-server/docker-compose.yml
+++ b/apps/signalk-server/docker-compose.yml
@@ -35,7 +35,11 @@ services:
       - /dev:/dev
       - /run:/run
     group_add:
-      - "960"  # halpid group for /run/halpid/halpid.sock access
+      # signalk-halpi reads /run/halpid/halpid.sock. halpid <5.1.0 owned it
+      # root:halpid (GID 960); 5.1.0+ owns it root:adm (GID 4). Grant both so
+      # the socket is reachable regardless of the installed halpid version.
+      - "960"  # halpid (legacy, halpid <5.1.0)
+      - "4"    # adm (halpid 5.1.0+)
     healthcheck:
       test: ["CMD-SHELL", "curl -sf http://localhost:3000/signalk || exit 1"]
       interval: 30s

--- a/apps/signalk-server/metadata.yaml
+++ b/apps/signalk-server/metadata.yaml
@@ -1,6 +1,6 @@
 name: Signal K Server
 app_id: signalk-server
-version: 2.30.0-1
+version: 2.30.0-2
 upstream_version: 2.30.0
 description: Signal K server for marine data processing and routing
 long_description: |


### PR DESCRIPTION
## Motivation

`halpid` 5.1.0 changed the ownership of `/run/halpid/halpid.sock` from `root:halpid` (GID 960) to `root:adm` (GID 4). The marine `signalk-server` container's `group_add` listed only GID 960, so the `node` user lost access to the socket. `signalk-halpi` then silently enters its error state and publishes nothing — `GET /signalk/v1/api/vessels/self/electrical/halpi` returns 404 with no visible error in the admin UI.

The deployed `marine-signalk-server-container/docker-compose.yml` is regenerated from this template on every HaLOS update, so the fix has to land in the template — a manual `group_add` edit on the device is reverted on the next update.

## Approach

Add GID `4` (`adm`) to `group_add` next to the existing `960`. `adm` is a statically-allocated Debian GID (base-passwd), so hardcoding `4` is stable across installs. Keeping `960` preserves access for devices still running halpid <5.1.0, covering the upgrade window in both directions.

Verified empirically in the issue: after granting GID 4 and restarting the container, the power-monitoring endpoint returns full data.

Bumps `apps/signalk-server/metadata.yaml` to `2.30.0-2` (CI app-level version check). Repo `VERSION` is unchanged — the version-bump check excludes `apps/*` from the repo-level cycle gate.

Fixes halos-org/halos#118