### PR TITLE
fix(avnav): update image to daily 20260709 for current ochartsng

### DIFF
--- a/apps/avnav/docker-compose.yml
+++ b/apps/avnav/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     # halos-proxy-network is auto-injected by container-packaging-tools
     ports:
       # Keep non-HTTP ports for external tool compatibility
-      - "${AVNAV_WEBSOCKET_PORT:-8083}:8083"  # WebSocket for chart plotters
+      - "${AVNAV_WEBSOCKET_PORT:-8083}:8083"  # ochartsng chart provider (shop UI, chart downloads)
       - "${AVNAV_NMEA_PORT:-34567}:34567"      # NMEA TCP stream
     volumes:
       - ${CONTAINER_DATA_ROOT}/data:/var/lib/avnav

--- a/apps/avnav/docker-compose.yml
+++ b/apps/avnav/docker-compose.yml
@@ -1,6 +1,9 @@
 services:
   avnav:
-    image: xfreex/avnav-stable:20251028
+    # Daily channel, not stable: upstream last rebuilt avnav-stable on
+    # 2025-10-28, and the ochartsng it bundles is rejected by the o-charts
+    # shop. Move back if upstream resumes stable builds.
+    image: xfreex/avnav-daily:20260709
     container_name: avnav
     init: true
     restart: unless-stopped

--- a/apps/avnav/metadata.yaml
+++ b/apps/avnav/metadata.yaml
@@ -41,7 +41,7 @@ web_ui:
   protocol: http
   visible: true
 routing:
-  port: 8080  # Main web UI port (not the exposed 8083 AvnavOchartsPro port)
+  port: 8080  # Main web UI port (not the exposed 8083 ochartsng provider port)
   auth:
     mode: forward_auth
 layout:

--- a/apps/avnav/metadata.yaml
+++ b/apps/avnav/metadata.yaml
@@ -1,7 +1,7 @@
 name: AvNav
 app_id: avnav
-version: 20251028-19
-upstream_version: "20251028"
+version: 20260709-1
+upstream_version: "20260709"
 description: Touch-optimized chart plotter for sailing and motor yachts
 long_description: |
   AvNav is a navigation software specifically designed for touch operation on


### PR DESCRIPTION
The pinned `xfreex/avnav-stable:20251028` bundles `avnav-ochartsng 20250822`, which the o-charts shop rejects with "Invalid version of the plugin code: 5". Users cannot log in to buy or refresh charts.

Upstream has not rebuilt the **stable** channel since 2025-10-28 — that tag and `latest` are its only two, both from the same day — so there is no newer stable image to move to. The daily channel is the only published image carrying a current ochartsng, so this switches channels rather than bumping a tag.

Verified by inspecting both arm64 images directly rather than trusting tags:

| package | stable:20251028 | daily:20260709 |
|---|---|---|
| `avnav-ochartsng` | 20250822 | **20260703** |
| `avnav` | 20250822 | 20260709 |
| `avnav-mapproxy-plugin` | 20250808 | 20260702 |

The version the plugin sends to the shop moves with it: `gui/index.js` builds its request as `version=r.1.0.0` in the stable image and `version=r.2.1.7` in the daily one. That parameter is what the shop validates. The reporter separately confirmed in [halos-org/halos#101](https://github.com/halos-org/halos/issues/101) that an in-place upgrade to ochartsng `20260304` restored login, so `20260703` clears it.

Base OS is unchanged (Debian 12 bookworm), and the image is multi-arch with arm64.

## Behaviour change worth knowing about

**The daily image does not ship `avnav-history-plugin`.** `/usr/lib/avnav/plugins/` goes from `{history, mapproxy, ochartsng}` to `{mapproxy, ochartsng}`. Nothing in this repo configures it, but AvNav auto-loads plugins, so users relying on its history graphs lose them on upgrade. That is the trade this makes: a working chart shop against a dropped plugin.

Neither the generated release notes nor the generated per-app deb changelog will say so on their own — the notes carry only the commit subject and the changelog template is a fixed stub — so [#230](https://github.com/halos-org/halos-marine-containers/issues/230) tracks hand-editing the release notes when this ships.

## Also in this PR

- A comment recording why the pin sits on the daily channel, so a later maintainer does not read it as accidental drift and move it back.
- Fly-by: port 8083 was described as a chart-plotter WebSocket in the compose file and as the "AvnavOchartsPro port" in `metadata.yaml`. It is neither — ochartsng's `plugin.py` declares it as the chart provider listener port. Both comments now say that. The `AVNAV_WEBSOCKET_PORT` variable keeps its name; renaming it would break devices that set it.

## Testing

`./run lint` (all 5 compose files valid) and the pytest suite (37 passed). Debian ordering confirmed with `dpkg --compare-versions`: `20260709-1` sorts above `20251028-19`.

No `VERSION` bump. `VERSION` is 0.4.0 against stable `v0.4.0+7`, so the cycle is not open — but `version-bump-check.yml` filters `^apps/` out of the changed-file list before the package-affecting test, so an apps-only change never opens one.

**Not verified end to end:** nobody has run an o-charts shop login against this image on a device. The mechanism is confirmed in code and the equivalent in-place upgrade was confirmed by the reporter, but the flow itself is untested. Worth doing before merge.

## Follow-ups filed

Review of this PR surfaced work that does not belong in a 3-line image bump:

| Topic | Issue |
|---|---|
| Third-party tag is mutable and prunable under a privileged container | [#228](https://github.com/halos-org/halos-marine-containers/issues/228) |
| Nightly image-update bot now auto-proposes preview-channel builds | [#229](https://github.com/halos-org/halos-marine-containers/issues/229) |
| Release notes must mention the history-plugin removal | [#230](https://github.com/halos-org/halos-marine-containers/issues/230) |
| Downgrade path after AvNav's in-place chart config migration | [#231](https://github.com/halos-org/halos-marine-containers/issues/231) |
| No CI check ties a compose tag to `metadata.yaml` `upstream_version` | [#232](https://github.com/halos-org/halos-marine-containers/issues/232) |
| NMEA port 34567 unauthenticated on pre-seed devices | [#233](https://github.com/halos-org/halos-marine-containers/issues/233) |
| Doubled restart policy hides a crash-looping container | [#234](https://github.com/halos-org/halos-marine-containers/issues/234) |
| `prestart.sh` accepts any Signal K host value, and has no tests | [#235](https://github.com/halos-org/halos-marine-containers/issues/235) |
| Upgrade stops the container before pulling the new image | [container-packaging-tools#247](https://github.com/halos-org/container-packaging-tools/issues/247) |

Issue [#190](https://github.com/halos-org/halos-marine-containers/issues/190) is **not** addressed here. The `discard request from %s, no local net` check is present in both provider builds, so the source-address restriction is unchanged; the analysis and a likely remedy are in [a comment there](https://github.com/halos-org/halos-marine-containers/issues/190#issuecomment-5232316333).

Closes halos-org/halos#101
