### PR TITLE
Drop "fleet-wide" from the image-pull note

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -313,8 +313,8 @@ systemctl reset-failed marine-signalk-server-container.service
 systemctl start marine-signalk-server-container.service
 ```
 
-This is fleet-wide, not specific to Signal K: every marine app pins an exact tag
-and fetches it the same way. Tracked in halos-org/container-packaging-tools#241.
+This is not specific to Signal K: every container app the generator emits pins an
+exact tag and fetches it the same way. Tracked in halos-org/container-packaging-tools#241.
 
 ### Authentication Negative Tests
 


### PR DESCRIPTION
One-line wording fix in `AGENTS.md`.

"Fleet" reads as vessel-fleet management in a marine product, and HaLOS explicitly does not do fleet management — so the word invites exactly the wrong reading. The intended meaning was the ops one: every container app the generator emits, on every device.

The same wording was corrected in place on halos-org/container-packaging-tools#241, #242 and #210.