### PR TITLE
Stop root writing the Signal K secret files through container-controlled paths

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -11,7 +11,10 @@ runs:
 
     - name: Install dependencies
       shell: bash
-      run: pip install pytest pyyaml
+      # bcrypt: apps/signalk-server/prestart.sh hashes the admin password
+      # with it, and the package declares python3-bcrypt as a runtime
+      # dependency. The harness used to stub it; the hook now imports it.
+      run: pip install pytest pyyaml bcrypt
 
     - name: Run pytest tests
       shell: bash

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -11,10 +11,10 @@ runs:
 
     - name: Install dependencies
       shell: bash
-      # bcrypt: apps/signalk-server/prestart.sh hashes the admin password
-      # with it, and the package declares python3-bcrypt as a runtime
-      # dependency. The harness used to stub it; the hook now imports it.
-      run: pip install pytest pyyaml bcrypt
+      # One source for all three consumers of these: this action, ./run test,
+      # and a bare local run. They drifted once already, and the CI-only copy
+      # meant ./run test failed on a dependency the suite needs.
+      run: pip install -r tests/requirements.txt
 
     - name: Run pytest tests
       shell: bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,9 +226,11 @@ pulls and boots the InfluxDB image.
 
 ### Signal K Prestart Hook
 
-`apps/signalk-server/prestart.sh` has a bash harness that stubs chown and bcrypt,
-so it needs no Docker, no network and no root. Unlike the InfluxDB harness it
-runs in CI, via `tests/test_signalk_prestart.py`:
+`apps/signalk-server/prestart.sh` has a bash harness that stubs chown, so it
+needs no Docker, no network and no root. bcrypt is not stubbed -- the python
+block that imports it is the thing under test -- so `python3-bcrypt` has to be
+installed to run this. Unlike the InfluxDB harness it runs in CI, via
+`tests/test_signalk_prestart.py`:
 
 ```bash
 ./tools/test-prestart.sh
@@ -246,13 +248,36 @@ Three of the hook's jobs look like leftovers and are not:
   `${SIGNALK_DATA}` to uid 1000, so the container — and any host process running
   as `pi`, which is the same uid — can unlink a file root is about to write and
   leave a symlink behind. Two mechanisms, and the second is the one that
-  generalises: a guard clears symlinks from the three named paths up front, and
-  every file *creation* uses `O_CREAT|O_EXCL` (`umask 077` + `set -o noclobber`
-  for the heredocs, `os.open` for the token rewrite), which refuses to follow a
-  link in one syscall. The guard alone is check-then-use and only covers paths
-  someone remembered to name — a temp file one line away from a guarded path was
-  a live arbitrary-root-write until review found it. Prefer `O_EXCL` to adding
-  another path to the guard.
+  generalises. All of it happens in one `python3` block, because the shell
+  cannot express the constraints:
+
+  - Each parent directory is opened once (`O_DIRECTORY|O_NOFOLLOW`) and every
+    operation below is `*at`-relative to that descriptor. Guarding named paths
+    cannot cover a swapped *parent*, because each syscall re-resolves the whole
+    path.
+  - Creates go through `O_CREAT|O_EXCL|O_NOFOLLOW`, which refuses to follow a
+    link in one syscall. `set -o noclobber` is **not** equivalent and must not be
+    used for this: bash stats the path first and adds `O_EXCL` only when that
+    stat fails, so a symlink to a FIFO or a device is followed.
+  - Modes converge as `open(O_NOFOLLOW)` + `fchmod`. `chmod(2)` always
+    dereferences and has no `--no-dereference`.
+  - Reads add `O_NONBLOCK` and check the type through the descriptor.
+    `O_NOFOLLOW` refuses a symlink but not a FIFO, and an `O_RDONLY` open of one
+    blocks until a writer appears — for root as much as anyone.
+  - The predicate is the file *type*, not "is a symlink", so a directory, FIFO,
+    socket or device at one of these names is handled too.
+
+  A guard alone is check-then-use and only covers paths someone remembered to
+  name — a temp file one line away from a guarded path was a live
+  arbitrary-root-write until review found it. Prefer `O_EXCL` to adding another
+  path to the guard.
+
+  Refusing to start is the answer when `security.json` cannot be made safe: an
+  open Signal K is worse than an absent one. That licence is narrow. `ExecStartPre`
+  gets five restarts before systemd stops trying, so an abort the container can
+  trigger on demand, or one caused by a fault that redirects nothing (a
+  read-only filesystem, a lost race), is a permanent outage bought for nothing.
+  Every failure path needs deciding in both directions.
 
   Scope: this is a property of *this hook*, not of the directory. Anything else
   that writes there as root needs the same care — `signalk-halpi`'s postinst
@@ -263,12 +288,18 @@ Three of the hook's jobs look like leftovers and are not:
   surviving symlink yields no root write, and one may be an operator relocating
   the tree to another disk. Only a dangling one is cleared.
 
+  `${CONTAINER_DATA_ROOT}/admin-password` gets the same treatment even though its
+  parent is root-owned and outside the bind mount, so the rule holds by
+  construction rather than by luck. It is also never handed to the container: it
+  is the emergency login when OIDC is what broke, and a `chown` of it to uid 1000
+  would give away the one credential meant to outlive a compromise.
+
   Paths that are safe today for a *different* reason, and would silently become
-  the same bug if that changed: `${CONTAINER_DATA_ROOT}/admin-password`,
-  `oidc-secret` and `$RUNTIME_ENV` are safe only because their parent is
-  root-owned and outside the bind mount; `settings.json` and `package.json` only
-  because they are `chown -h`'d and never written. Mount `${CONTAINER_DATA_ROOT}`
-  into a container, or add a `cat >` to `settings.json`, and they are exposed.
+  the same bug if that changed: `oidc-secret` and `$RUNTIME_ENV` are safe only
+  because their parent is root-owned and outside the bind mount; `settings.json`
+  and `package.json` only because they are `chown -h`'d and never written. Mount
+  `${CONTAINER_DATA_ROOT}` into a container, or add a `cat >` to `settings.json`,
+  and they are exposed.
 
 - **`node_modules` and `package.json` are handed to uid 1000 on every start.**
   `signalk-halpi`'s postinst creates both as root when it registers itself as a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -234,7 +234,7 @@ runs in CI, via `tests/test_signalk_prestart.py`:
 ./tools/test-prestart.sh
 ```
 
-Two of the hook's jobs look like leftovers and are not:
+Three of the hook's jobs look like leftovers and are not:
 
 - **The InfluxDB config is written without checking that the plugin is
   installed.** The plugin is baked into the image, so the data volume holds no

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -242,6 +242,15 @@ Two of the hook's jobs look like leftovers and are not:
   `${SIGNALK_DATA}/node_modules/signalk-to-influxdb2` was false on every device
   that had not updated the plugin through the app store -- so the token was never
   written, the server started, and only the graphs stayed empty.
+- **Symlinks are cleared from the paths root writes, before it writes them.**
+  `security.json`, `plugin-config-data/` and the InfluxDB token config all live
+  in a directory this hook hands to uid 1000, so the container can unlink any of
+  them and leave a symlink behind. `chmod`, `touch` and `cat >` all dereference,
+  which turns a container foothold into a host-root write. Root never creates a
+  symlink at those paths, so removing one only ever undoes tampering — unlike
+  `node_modules`, where a symlink may be a deliberate relocation and only a
+  dangling one is cleared.
+
 - **`node_modules` and `package.json` are handed to uid 1000 on every start.**
   `signalk-halpi`'s postinst creates both as root when it registers itself as a
   `file:` dependency, and the pi-gen plugin stages do the same on an imaged

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -242,14 +242,33 @@ Three of the hook's jobs look like leftovers and are not:
   `${SIGNALK_DATA}/node_modules/signalk-to-influxdb2` was false on every device
   that had not updated the plugin through the app store -- so the token was never
   written, the server started, and only the graphs stayed empty.
-- **Symlinks are cleared from the paths root writes, before it writes them.**
-  `security.json`, `plugin-config-data/` and the InfluxDB token config all live
-  in a directory this hook hands to uid 1000, so the container can unlink any of
-  them and leave a symlink behind. `chmod`, `touch` and `cat >` all dereference,
-  which turns a container foothold into a host-root write. Root never creates a
-  symlink at those paths, so removing one only ever undoes tampering — unlike
-  `node_modules`, where a symlink may be a deliberate relocation and only a
-  dangling one is cleared.
+- **Root never writes through a symlink into the data volume.** This hook hands
+  `${SIGNALK_DATA}` to uid 1000, so the container — and any host process running
+  as `pi`, which is the same uid — can unlink a file root is about to write and
+  leave a symlink behind. Two mechanisms, and the second is the one that
+  generalises: a guard clears symlinks from the three named paths up front, and
+  every file *creation* uses `O_CREAT|O_EXCL` (`umask 077` + `set -o noclobber`
+  for the heredocs, `os.open` for the token rewrite), which refuses to follow a
+  link in one syscall. The guard alone is check-then-use and only covers paths
+  someone remembered to name — a temp file one line away from a guarded path was
+  a live arbitrary-root-write until review found it. Prefer `O_EXCL` to adding
+  another path to the guard.
+
+  Scope: this is a property of *this hook*, not of the directory. Anything else
+  that writes there as root needs the same care — `signalk-halpi`'s postinst
+  writes `plugin-config-data/signalk-halpi.json` and `package.json` into it and
+  does not have it (hatlabs/signalk-halpi#26).
+
+  `node_modules` is deliberately different: nothing here writes into it, so a
+  surviving symlink yields no root write, and one may be an operator relocating
+  the tree to another disk. Only a dangling one is cleared.
+
+  Paths that are safe today for a *different* reason, and would silently become
+  the same bug if that changed: `${CONTAINER_DATA_ROOT}/admin-password`,
+  `oidc-secret` and `$RUNTIME_ENV` are safe only because their parent is
+  root-owned and outside the bind mount; `settings.json` and `package.json` only
+  because they are `chown -h`'d and never written. Mount `${CONTAINER_DATA_ROOT}`
+  into a container, or add a `cat >` to `settings.json`, and they are exposed.
 
 - **`node_modules` and `package.json` are handed to uid 1000 on every start.**
   `signalk-halpi`'s postinst creates both as root when it registers itself as a

--- a/apps/signalk-server/metadata.yaml
+++ b/apps/signalk-server/metadata.yaml
@@ -1,6 +1,6 @@
 name: Signal K Server
 app_id: signalk-server
-version: 2.30.0-4
+version: 2.30.0-5
 upstream_version: 2.30.0
 description: Signal K server for marine data processing and routing
 long_description: |

--- a/apps/signalk-server/prestart.sh
+++ b/apps/signalk-server/prestart.sh
@@ -14,117 +14,244 @@ PLUGIN_CONFIG="${PLUGIN_CONFIG_DIR}/signalk-to-influxdb2.json"
 # Create data directory if needed
 mkdir -p "${SIGNALK_DATA}"
 
-# Root writes the files below, and their parent is handed to uid 1000 at the end
-# of this hook -- so the container can unlink any of them and leave a symlink in
-# its place. Every operation that follows dereferences: chmod, touch, cat >, and
-# the chown on security.json. Left unguarded that is a container-to-host-root
-# escalation, reproduced against /etc/ld.so.preload: root creates the target,
-# writes the JSON into it, and hands it to uid 1000, which then writes a .so path
-# every later root process preloads. The existing-target variant is a tamper
-# primitive on its own -- the chmod 600 alone strips the mode off whatever the
-# link points at.
+# --- secret files -----------------------------------------------------------
+# security.json (admin hash + JWT signing key) and the InfluxDB token config are
+# written by root into a directory this hook hands to uid 1000, so the container
+# -- and any host process running as pi, the same uid -- can put something else
+# at those names first.
 #
-# Root never creates a symlink at any of these paths, so removing one is only
-# ever undoing tampering. node_modules further down is deliberately different:
-# a symlink there can be an operator relocating the plugin tree to another disk,
-# so only a dangling one is cleared.
+# All of it happens in one python3 block, for reasons three rounds of shell got
+# wrong:
 #
-# Failing to clear one aborts the hook rather than writing through it. The
-# framework sources this under set -e, so a non-zero return here withholds the
-# app -- the correct outcome when the alternative is root writing to a path the
-# container chose.
-drop_symlink() {  # $1 = path, $2 = optional consequence to warn about
-    [ -L "$1" ] || return 0
-    echo "WARNING: removing unexpected symlink at $1"
-    [ -n "${2:-}" ] && echo "WARNING: $2"
-    # -rf rather than -f: between the test above and this line the path can turn
-    # into a real directory, which rm -f refuses -- and a non-zero return here
-    # withholds the app on every boot until someone runs reset-failed by hand.
-    # Root can always clear a path whose parent it owns, so give it the chance
-    # before failing. Only a path that was a symlink a moment ago reaches this,
-    # so nothing an operator put here deliberately is at risk.
-    rm -rf "$1" || {
-        echo "ERROR: could not remove ${1}; refusing to write through it"
-        return 1
-    }
-}
-# Parent before child: clearing a symlinked directory changes what the paths
-# below it resolve to.
-drop_symlink "${PLUGIN_CONFIG_DIR}"
-drop_symlink "${SECURITY_FILE}" \
-    "a fresh security.json follows: the admin password and the JWT signing key are regenerated, so existing tokens and device approvals stop validating, and whatever the link pointed at is left where it is"
-drop_symlink "${PLUGIN_CONFIG}"
-
-# Earlier versions created both of these 0644, so every already-deployed device
-# carries the admin hash, the JWT signing key and the InfluxDB admin token in a
-# world-readable file. Restricted here rather than only at creation, because on
-# those devices the file already exists. Everything created below is written
-# restricted in the first place.
-if [ -f "${SECURITY_FILE}" ]; then
-    chmod 600 "${SECURITY_FILE}"
-fi
-if [ -f "${PLUGIN_CONFIG}" ]; then
-    chmod 600 "${PLUGIN_CONFIG}"
+#   * chmod(2) always dereferences and has no --no-dereference, so converging a
+#     mode is only safe as open(O_NOFOLLOW) + fchmod.
+#   * `set -o noclobber` is NOT O_EXCL. Bash stats the path first and adds
+#     O_EXCL only when that stat fails, so a symlink to a FIFO or a device node
+#     is followed -- and a FIFO with a reader made the hook log success while
+#     streaming the secrets to whoever held the read end.
+#   * Guarding named paths cannot cover a swapped *parent*, because every
+#     syscall re-resolves the whole path. The parent is opened once here and
+#     everything is *at-relative to that descriptor.
+#   * Checking for a symlink was the wrong predicate: a plain `mkdir` at
+#     security.json wedged ExecStartPre on every boot. The check is on the file
+#     type, so a directory, FIFO, socket or device is handled too.
+#
+# The token is read before the block so python needs no shell interpolation.
+INFLUXDB_ENV="${INFLUXDB_ENV:-/etc/container-apps/marine-influxdb-container/env}"
+INFLUXDB_ADMIN_TOKEN=""
+if [ -f "${INFLUXDB_ENV}" ]; then
+    INFLUXDB_ADMIN_TOKEN=$(grep '^INFLUXDB_ADMIN_TOKEN=' "${INFLUXDB_ENV}" | cut -d= -f2-)
 fi
 
-# Only create security.json if it doesn't exist
-if [ ! -f "${SECURITY_FILE}" ]; then
-    echo "Creating initial security.json with default admin user..."
+HALOS_DATA_ROOT="${CONTAINER_DATA_ROOT}" \
+HALOS_SK_DATA="${SIGNALK_DATA}" \
+HALOS_INFLUX_TOKEN="${INFLUXDB_ADMIN_TOKEN}" \
+python3 - <<'HALOS_SECRETS_PY'
+import json, os, secrets, stat, sys
 
-    # Generate a random password (32 character hex string)
-    ADMIN_PASSWORD=$(openssl rand -hex 16)
+import bcrypt
 
-    # Hash the password using Python bcrypt (via stdin for robustness)
-    # python3-bcrypt is a dependency of the package
-    HASHED_PASSWORD=$(printf '%s' "${ADMIN_PASSWORD}" | python3 -c "import sys, bcrypt; print(bcrypt.hashpw(sys.stdin.buffer.read(), bcrypt.gensalt()).decode())")
+DATA_ROOT = os.environ["HALOS_DATA_ROOT"]
+SK_DATA = os.environ["HALOS_SK_DATA"]
+INFLUX_TOKEN = os.environ.get("HALOS_INFLUX_TOKEN") or ""
 
-    # Generate a secret key for JWT tokens
-    SECRET_KEY=$(openssl rand -hex 32)
 
-    # Holds the admin bcrypt hash and the JWT signing key.
-    #
-    # noclobber, not touch-then-chmod: it makes bash open with O_CREAT|O_EXCL,
-    # which refuses to follow a symlink at the final component. The guard near
-    # the top clears a link that is already there, but the container owns this
-    # directory and can plant one in the window between that check and here --
-    # O_EXCL closes the window instead of narrowing it, in one syscall. umask
-    # 077 means the secrets are 0600 from creation rather than briefly 0644
-    # between touch and chmod. Subshell so neither setting leaks to the rest of
-    # the hook.
-    (
-        umask 077
-        set -o noclobber
-        cat > "${SECURITY_FILE}" << EOF
-{
-  "strategy": "./tokensecurity",
-  "users": [
-    {
-      "username": "admin",
-      "type": "admin",
-      "password": "${HASHED_PASSWORD}"
-    }
-  ],
-  "allow_readonly": true,
-  "secretKey": "${SECRET_KEY}"
-}
-EOF
+def warn(msg):
+    print("WARNING: " + msg, flush=True)
+
+
+def open_dir(path, parent_fd=None):
+    """Pin a directory by descriptor.
+
+    Everything below operates *at-relative to this fd, so the parent cannot be
+    swapped between one syscall and the next -- the gap no per-path check can
+    close, because each syscall otherwise re-resolves the whole path.
+    """
+    return os.open(
+        path, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW, dir_fd=parent_fd
     )
 
-    # Set proper ownership (match container user - node:node is 1000:1000).
-    # -h like every other chown here, so a link planted between the O_EXCL create
-    # above and this line is not followed. With the create no longer
-    # dereferencing, this is the last operation in the branch that could.
-    chown -h 1000:1000 "${SECURITY_FILE}"
 
-    echo "Security initialized with admin user."
-    echo "NOTE: Local admin password stored in ${CONTAINER_DATA_ROOT}/admin-password"
-    echo "This is a fallback for emergency access. Use OIDC for regular login."
+def clear_unexpected(dfd, name, want_dir=False):
+    """Make `name` absent or the type we need, without following anything.
 
-    # Store the password for emergency recovery
-    touch "${CONTAINER_DATA_ROOT}/admin-password"
-    chmod 600 "${CONTAINER_DATA_ROOT}/admin-password"
-    echo "${ADMIN_PASSWORD}" > "${CONTAINER_DATA_ROOT}/admin-password"
-fi
+    Root creates only a regular file (or, for the config dir, a directory) at
+    these names. Anything else is tampering or wreckage, and the check is on
+    the *type*, not on being a symlink: a plain `mkdir` at security.json wedged
+    every boot, and a FIFO made the hook report success while streaming the
+    secrets to whoever held the read end.
+
+    A wrong-type directory is renamed aside rather than deleted -- it may hold
+    an operator's data, and moving it both preserves that and unblocks the
+    create. Everything else (symlink, FIFO, socket, device) is something root
+    never creates here, so unlinking loses nothing.
+    """
+    try:
+        st = os.lstat(name, dir_fd=dfd)
+    except FileNotFoundError:
+        return True
+
+    if stat.S_ISDIR(st.st_mode) if want_dir else stat.S_ISREG(st.st_mode):
+        return True
+
+    kind = "directory" if stat.S_ISDIR(st.st_mode) else (
+        "symlink" if stat.S_ISLNK(st.st_mode) else "non-regular file"
+    )
+    warn(f"unexpected {kind} at {name}; clearing it")
+    try:
+        if stat.S_ISDIR(st.st_mode):
+            os.rename(name, name + ".unexpected",
+                      src_dir_fd=dfd, dst_dir_fd=dfd)
+            warn(f"moved aside to {name}.unexpected; its contents are intact")
+        else:
+            os.unlink(name, dir_fd=dfd)
+    except OSError as exc:
+        warn(f"could not clear {name}: {exc}")
+        return False
+    return True
+
+
+def create_exclusive(dfd, name, content):
+    """Create and fill `name`, refusing to follow anything.
+
+    O_EXCL|O_NOFOLLOW is a real kernel exclusive create, and the mode is applied
+    at creation so the secrets are never briefly world-readable. Bash's
+    `noclobber` is NOT equivalent: it stats first and only adds O_EXCL when that
+    stat fails, so a symlink to a FIFO or a device is followed.
+    """
+    fd = os.open(
+        name,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+        0o600,
+        dir_fd=dfd,
+    )
+    try:
+        os.fchmod(fd, 0o600)  # explicit: the mode above is masked by umask
+        with os.fdopen(fd, "w") as f:
+            f.write(content)
+    except BaseException:
+        os.close(fd)
+        raise
+
+
+def converge_mode(dfd, name):
+    """Restrict an existing file without re-resolving its path.
+
+    chmod(2) always dereferences and has no --no-dereference, so the only safe
+    form is to open the file O_NOFOLLOW and fchmod the descriptor.
+    """
+    try:
+        fd = os.open(name, os.O_RDONLY | os.O_NOFOLLOW, dir_fd=dfd)
+    except (FileNotFoundError, OSError):
+        return
+    try:
+        os.fchmod(fd, 0o600)
+    finally:
+        os.close(fd)
+
+
+# --- security.json -----------------------------------------------------------
+# Failure here aborts the hook. A Signal K with no security configuration is
+# not a degraded install, it is an open one, and the causes that remain after
+# the type check above are real filesystem faults rather than anything the
+# container can arrange.
+sk_fd = open_dir(SK_DATA)
+root_fd = open_dir(DATA_ROOT)
+
+if not clear_unexpected(sk_fd, "security.json"):
+    sys.exit("ERROR: cannot make security.json safe to write; refusing to start")
+
+converge_mode(sk_fd, "security.json")
+
+try:
+    os.lstat("security.json", dir_fd=sk_fd)
+except FileNotFoundError:
+    print("Creating initial security.json with default admin user...")
+    password = secrets.token_hex(16)
+    hashed = bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
+    create_exclusive(sk_fd, "security.json", json.dumps({
+        "strategy": "./tokensecurity",
+        "users": [{"username": "admin", "type": "admin", "password": hashed}],
+        "allow_readonly": True,
+        "secretKey": secrets.token_hex(32),
+    }, indent=2) + "\n")
+
+    # Emergency access only; OIDC is the normal login path. Its parent is
+    # root-owned and outside the bind mount, but it is created the same way so
+    # the rule holds by construction rather than by luck.
+    clear_unexpected(root_fd, "admin-password")
+    try:
+        os.unlink("admin-password", dir_fd=root_fd)
+    except FileNotFoundError:
+        pass
+    create_exclusive(root_fd, "admin-password", password + "\n")
+    print("Security initialized with admin user.")
+    print(f"NOTE: Local admin password stored in {DATA_ROOT}/admin-password")
+    print("This is a fallback for emergency access. Use OIDC for regular login.")
+
+# --- InfluxDB plugin config --------------------------------------------------
+# Failure here only warns. Logging is not navigation, and the alternative is a
+# unit that never starts.
+if INFLUX_TOKEN:
+    if clear_unexpected(sk_fd, "plugin-config-data", want_dir=True):
+        try:
+            os.mkdir("plugin-config-data", 0o755, dir_fd=sk_fd)
+        except FileExistsError:
+            pass
+        try:
+            cfg_fd = open_dir("plugin-config-data", parent_fd=sk_fd)
+        except OSError as exc:
+            cfg_fd = None
+            warn(f"cannot open plugin-config-data: {exc}")
+
+        if cfg_fd is not None:
+            name = "signalk-to-influxdb2.json"
+            if clear_unexpected(cfg_fd, name):
+                converge_mode(cfg_fd, name)
+                try:
+                    fd = os.open(name, os.O_RDONLY | os.O_NOFOLLOW,
+                                 dir_fd=cfg_fd)
+                except FileNotFoundError:
+                    create_exclusive(cfg_fd, name, json.dumps({
+                        "enabled": True,
+                        "configuration": {"influxes": [{
+                            "url": "http://localhost:8086",
+                            "token": INFLUX_TOKEN,
+                            "org": "marine",
+                            "bucket": "marine",
+                            "onlySelf": True,
+                            "resolution": 1000,
+                        }]},
+                    }, indent=2) + "\n")
+                    print("InfluxDB plugin configured")
+                else:
+                    # Read through the descriptor, not the path: json.load on a
+                    # re-planted symlink would copy a root-only file out, and
+                    # os.replace would then leave it here owned by uid 1000.
+                    try:
+                        with os.fdopen(fd) as f:
+                            cfg = json.load(f)
+                        influxes = cfg.get("configuration", {}).get("influxes", [])
+                        if influxes:
+                            influxes[0]["token"] = INFLUX_TOKEN
+                        tmp = name + ".tmp"
+                        clear_unexpected(cfg_fd, tmp)
+                        try:
+                            os.unlink(tmp, dir_fd=cfg_fd)
+                        except FileNotFoundError:
+                            pass
+                        create_exclusive(cfg_fd, tmp,
+                                         json.dumps(cfg, indent=2) + "\n")
+                        os.replace(tmp, name,
+                                   src_dir_fd=cfg_fd, dst_dir_fd=cfg_fd)
+                        print("InfluxDB plugin token updated")
+                    except (OSError, ValueError) as exc:
+                        warn(f"failed to update InfluxDB token: {exc}")
+            os.close(cfg_fd)
+
+os.close(sk_fd)
+os.close(root_fd)
+HALOS_SECRETS_PY
 
 # Signal K advertises its external URL via mDNS from these. EXTERNALHOST strips
 # the .local suffix that Signal K's dnssd library re-appends; the external port
@@ -137,91 +264,6 @@ EXTERNAL_PORT="$(grep '^signalk-server=' /etc/halos/port-registry 2>/dev/null | 
     # Requires upstream EXTERNALSSL support: https://github.com/SignalK/signalk-server/pull/2484
     echo "EXTERNALSSL=1"
 } >> "$RUNTIME_ENV"
-
-# --- InfluxDB plugin configuration ---
-# signalk-to-influxdb2 is baked into the image, so the data volume cannot attest
-# to it. A presence check under ${SIGNALK_DATA}/node_modules is false on every
-# freshly imaged device -- nothing puts the plugin there any more -- and writing
-# the token config is then skipped for the whole life of that device, silently:
-# the server starts, and only the graphs stay empty. The token lives in the
-# InfluxDB container's env and is rewritten here on every start, because rotating
-# it there must reach this config.
-INFLUXDB_ENV="${INFLUXDB_ENV:-/etc/container-apps/marine-influxdb-container/env}"
-
-if [ -f "${INFLUXDB_ENV}" ]; then
-    INFLUXDB_ADMIN_TOKEN=$(grep '^INFLUXDB_ADMIN_TOKEN=' "${INFLUXDB_ENV}" | cut -d= -f2-)
-
-    if [ -n "${INFLUXDB_ADMIN_TOKEN}" ]; then
-        # Write plugin config (first time only) or update token
-        mkdir -p "${PLUGIN_CONFIG_DIR}"
-        if [ ! -f "${PLUGIN_CONFIG}" ]; then
-            # Carries the InfluxDB admin token. umask + noclobber for the same
-            # reason as security.json above: O_CREAT|O_EXCL will not follow a
-            # symlink planted after the guard ran, and the token is never
-            # briefly world-readable.
-            (
-            umask 077
-            set -o noclobber
-            cat > "${PLUGIN_CONFIG}" << PLUGINEOF
-{
-  "enabled": true,
-  "configuration": {
-    "influxes": [
-      {
-        "url": "http://localhost:8086",
-        "token": "${INFLUXDB_ADMIN_TOKEN}",
-        "org": "marine",
-        "bucket": "marine",
-        "onlySelf": true,
-        "resolution": 1000
-      }
-    ]
-  }
-}
-PLUGINEOF
-            )
-            echo "InfluxDB plugin configured"
-        else
-            # Update token in existing config without overwriting other settings
-            # Rewritten via a temp file and os.replace: truncating the live path
-            # means a kill between open('w') and the dump leaves it zero-length,
-            # and every later boot then fails json.load, warns, and carries on
-            # with the plugin's settings gone for good. apps/influxdb/prestart.sh
-            # writes the same class of file the same way.
-            if INFLUX_TOKEN="${INFLUXDB_ADMIN_TOKEN}" python3 - "${PLUGIN_CONFIG}" <<'PYEOF'; then
-import json, os, sys
-path = sys.argv[1]
-with open(path) as f:
-    cfg = json.load(f)
-influxes = cfg.get('configuration', {}).get('influxes', [])
-if influxes:
-    influxes[0]['token'] = os.environ['INFLUX_TOKEN']
-# O_EXCL rather than open(tmp, 'w'): this directory is handed to uid 1000 on
-# every run, so the container can pre-create the temp path as a symlink and
-# redirect root's write exactly as it could the config itself. O_CREAT|O_EXCL
-# refuses to follow a symlink at the final component, and does it in one
-# syscall -- unlike a check-then-write guard, there is no window to lose. The
-# unlink clears a leftover from a killed run; if the link is re-planted in
-# between, the open fails and the shell branch below reports it, which is the
-# right direction to fail.
-tmp = path + '.tmp'
-try:
-    os.unlink(tmp)
-except FileNotFoundError:
-    pass
-fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
-os.fchmod(fd, 0o600)  # explicit: the mode above is masked by umask
-with os.fdopen(fd, 'w') as f:
-    json.dump(cfg, f, indent=2)
-os.replace(tmp, path)
-PYEOF
-                echo "InfluxDB plugin token updated"
-            else
-                echo "WARNING: Failed to update InfluxDB token in plugin config"
-            fi
-        fi
-    fi
-fi
 
 # Reclaim what the retired provisioning hook left behind. npm-cache holds the
 # tarballs and metadata for the whole curated set -- easily hundreds of MB on an
@@ -239,6 +281,12 @@ fi
 # -h throughout: these live in a directory the container can write, so following
 # a symlink would let it choose which host path root hands over.
 chown -h 1000:1000 "${SIGNALK_DATA}"
+# Unconditional, not inside a create branch: the python block above may have
+# created security.json on this run or on any earlier one, and the container
+# cannot log anyone in through a file it does not own.
+if [ -f "${SECURITY_FILE}" ]; then
+    chown -h 1000:1000 "${SECURITY_FILE}"
+fi
 if [ -f "${SIGNALK_DATA}/settings.json" ]; then
     chown -h 1000:1000 "${SIGNALK_DATA}/settings.json"
 fi

--- a/apps/signalk-server/prestart.sh
+++ b/apps/signalk-server/prestart.sh
@@ -73,11 +73,20 @@ if [ ! -f "${SECURITY_FILE}" ]; then
     # Generate a secret key for JWT tokens
     SECRET_KEY=$(openssl rand -hex 32)
 
-    # Holds the admin bcrypt hash and the JWT signing key. Restricted before the
-    # first write rather than after, so the secrets never sit in a 0644 file.
-    touch "${SECURITY_FILE}"
-    chmod 600 "${SECURITY_FILE}"
-    cat > "${SECURITY_FILE}" << EOF
+    # Holds the admin bcrypt hash and the JWT signing key.
+    #
+    # noclobber, not touch-then-chmod: it makes bash open with O_CREAT|O_EXCL,
+    # which refuses to follow a symlink at the final component. The guard near
+    # the top clears a link that is already there, but the container owns this
+    # directory and can plant one in the window between that check and here --
+    # O_EXCL closes the window instead of narrowing it, in one syscall. umask
+    # 077 means the secrets are 0600 from creation rather than briefly 0644
+    # between touch and chmod. Subshell so neither setting leaks to the rest of
+    # the hook.
+    (
+        umask 077
+        set -o noclobber
+        cat > "${SECURITY_FILE}" << EOF
 {
   "strategy": "./tokensecurity",
   "users": [
@@ -91,12 +100,12 @@ if [ ! -f "${SECURITY_FILE}" ]; then
   "secretKey": "${SECRET_KEY}"
 }
 EOF
+    )
 
     # Set proper ownership (match container user - node:node is 1000:1000).
-    # -h like every other chown here: the guard above clears a symlink before we
-    # start writing, but the container owns this directory and can plant a fresh
-    # one in the window between that check and this line. -h makes the race
-    # unwinnable rather than merely unlikely.
+    # -h like every other chown here, so a link planted between the O_EXCL create
+    # above and this line is not followed. With the create no longer
+    # dereferencing, this is the last operation in the branch that could.
     chown -h 1000:1000 "${SECURITY_FILE}"
 
     echo "Security initialized with admin user."
@@ -138,9 +147,13 @@ if [ -f "${INFLUXDB_ENV}" ]; then
         # Write plugin config (first time only) or update token
         mkdir -p "${PLUGIN_CONFIG_DIR}"
         if [ ! -f "${PLUGIN_CONFIG}" ]; then
-            # Carries the InfluxDB admin token.
-            touch "${PLUGIN_CONFIG}"
-            chmod 600 "${PLUGIN_CONFIG}"
+            # Carries the InfluxDB admin token. umask + noclobber for the same
+            # reason as security.json above: O_CREAT|O_EXCL will not follow a
+            # symlink planted after the guard ran, and the token is never
+            # briefly world-readable.
+            (
+            umask 077
+            set -o noclobber
             cat > "${PLUGIN_CONFIG}" << PLUGINEOF
 {
   "enabled": true,
@@ -158,6 +171,7 @@ if [ -f "${INFLUXDB_ENV}" ]; then
   }
 }
 PLUGINEOF
+            )
             echo "InfluxDB plugin configured"
         else
             # Update token in existing config without overwriting other settings
@@ -174,10 +188,23 @@ with open(path) as f:
 influxes = cfg.get('configuration', {}).get('influxes', [])
 if influxes:
     influxes[0]['token'] = os.environ['INFLUX_TOKEN']
+# O_EXCL rather than open(tmp, 'w'): this directory is handed to uid 1000 on
+# every run, so the container can pre-create the temp path as a symlink and
+# redirect root's write exactly as it could the config itself. O_CREAT|O_EXCL
+# refuses to follow a symlink at the final component, and does it in one
+# syscall -- unlike a check-then-write guard, there is no window to lose. The
+# unlink clears a leftover from a killed run; if the link is re-planted in
+# between, the open fails and the shell branch below reports it, which is the
+# right direction to fail.
 tmp = path + '.tmp'
-with open(tmp, 'w') as f:
+try:
+    os.unlink(tmp)
+except FileNotFoundError:
+    pass
+fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+os.fchmod(fd, 0o600)  # explicit: the mode above is masked by umask
+with os.fdopen(fd, 'w') as f:
     json.dump(cfg, f, indent=2)
-os.chmod(tmp, 0o600)
 os.replace(tmp, path)
 PYEOF
                 echo "InfluxDB plugin token updated"

--- a/apps/signalk-server/prestart.sh
+++ b/apps/signalk-server/prestart.sh
@@ -14,6 +14,39 @@ PLUGIN_CONFIG="${PLUGIN_CONFIG_DIR}/signalk-to-influxdb2.json"
 # Create data directory if needed
 mkdir -p "${SIGNALK_DATA}"
 
+# Root writes the files below, and their parent is handed to uid 1000 at the end
+# of this hook -- so the container can unlink any of them and leave a symlink in
+# its place. Every operation that follows dereferences: chmod, touch, cat >, and
+# the chown on security.json. Left unguarded that is a container-to-host-root
+# escalation, reproduced against /etc/ld.so.preload: root creates the target,
+# writes the JSON into it, and hands it to uid 1000, which then writes a .so path
+# every later root process preloads. The existing-target variant is a tamper
+# primitive on its own -- the chmod 600 alone strips the mode off whatever the
+# link points at.
+#
+# Root never creates a symlink at any of these paths, so removing one is only
+# ever undoing tampering. node_modules further down is deliberately different:
+# a symlink there can be an operator relocating the plugin tree to another disk,
+# so only a dangling one is cleared.
+#
+# Failing to clear one aborts the hook rather than writing through it. The
+# framework sources this under set -e, so a non-zero return here withholds the
+# app -- the correct outcome when the alternative is root writing to a path the
+# container chose.
+drop_symlink() {
+    [ -L "$1" ] || return 0
+    echo "WARNING: removing unexpected symlink at $1"
+    rm -f "$1" || {
+        echo "ERROR: could not remove ${1}; refusing to write through it"
+        return 1
+    }
+}
+# Parent before child: clearing a symlinked directory changes what the paths
+# below it resolve to.
+drop_symlink "${PLUGIN_CONFIG_DIR}"
+drop_symlink "${SECURITY_FILE}"
+drop_symlink "${PLUGIN_CONFIG}"
+
 # Earlier versions created both of these 0644, so every already-deployed device
 # carries the admin hash, the JWT signing key and the InfluxDB admin token in a
 # world-readable file. Restricted here rather than only at creation, because on
@@ -59,8 +92,12 @@ if [ ! -f "${SECURITY_FILE}" ]; then
 }
 EOF
 
-    # Set proper ownership (match container user - node:node is 1000:1000)
-    chown 1000:1000 "${SECURITY_FILE}"
+    # Set proper ownership (match container user - node:node is 1000:1000).
+    # -h like every other chown here: the guard above clears a symlink before we
+    # start writing, but the container owns this directory and can plant a fresh
+    # one in the window between that check and this line. -h makes the race
+    # unwinnable rather than merely unlikely.
+    chown -h 1000:1000 "${SECURITY_FILE}"
 
     echo "Security initialized with admin user."
     echo "NOTE: Local admin password stored in ${CONTAINER_DATA_ROOT}/admin-password"

--- a/apps/signalk-server/prestart.sh
+++ b/apps/signalk-server/prestart.sh
@@ -9,7 +9,6 @@
 SIGNALK_DATA="${CONTAINER_DATA_ROOT}/data"
 SECURITY_FILE="${SIGNALK_DATA}/security.json"
 PLUGIN_CONFIG_DIR="${SIGNALK_DATA}/plugin-config-data"
-PLUGIN_CONFIG="${PLUGIN_CONFIG_DIR}/signalk-to-influxdb2.json"
 
 # Create data directory if needed
 mkdir -p "${SIGNALK_DATA}"
@@ -20,21 +19,28 @@ mkdir -p "${SIGNALK_DATA}"
 # -- and any host process running as pi, the same uid -- can put something else
 # at those names first.
 #
-# All of it happens in one python3 block, for reasons three rounds of shell got
-# wrong:
+# All of it happens in one python3 block, because the shell cannot express the
+# constraints:
 #
 #   * chmod(2) always dereferences and has no --no-dereference, so converging a
 #     mode is only safe as open(O_NOFOLLOW) + fchmod.
 #   * `set -o noclobber` is NOT O_EXCL. Bash stats the path first and adds
 #     O_EXCL only when that stat fails, so a symlink to a FIFO or a device node
-#     is followed -- and a FIFO with a reader made the hook log success while
-#     streaming the secrets to whoever held the read end.
+#     is followed.
 #   * Guarding named paths cannot cover a swapped *parent*, because every
-#     syscall re-resolves the whole path. The parent is opened once here and
-#     everything is *at-relative to that descriptor.
-#   * Checking for a symlink was the wrong predicate: a plain `mkdir` at
-#     security.json wedged ExecStartPre on every boot. The check is on the file
-#     type, so a directory, FIFO, socket or device is handled too.
+#     syscall re-resolves the whole path. The parents are opened once here and
+#     everything is *at-relative to those descriptors.
+#   * The predicate is the file type, not "is a symlink": a directory, FIFO,
+#     socket or device at one of these names has to be handled too.
+#   * O_NOFOLLOW refuses a symlink but not a FIFO, and opening a FIFO to read
+#     blocks until a writer appears -- for root as much as anyone. Reads add
+#     O_NONBLOCK and check the type through the descriptor.
+#
+# Refusing to start is the answer when security.json cannot be made safe: an
+# open Signal K is worse than an absent one. That licence is narrow. An abort
+# the container can trigger on demand, or one caused by a fault that redirects
+# nothing, is a permanent outage bought for nothing -- ExecStartPre gets five
+# restarts before systemd stops trying.
 #
 # The token is read before the block so python needs no shell interpolation.
 INFLUXDB_ENV="${INFLUXDB_ENV:-/etc/container-apps/marine-influxdb-container/env}"
@@ -46,14 +52,16 @@ fi
 HALOS_DATA_ROOT="${CONTAINER_DATA_ROOT}" \
 HALOS_SK_DATA="${SIGNALK_DATA}" \
 HALOS_INFLUX_TOKEN="${INFLUXDB_ADMIN_TOKEN}" \
-python3 - <<'HALOS_SECRETS_PY'
-import json, os, secrets, stat, sys
-
-import bcrypt
+python3 -P - <<'HALOS_SECRETS_PY'
+import errno, json, os, secrets, stat, sys
 
 DATA_ROOT = os.environ["HALOS_DATA_ROOT"]
 SK_DATA = os.environ["HALOS_SK_DATA"]
 INFLUX_TOKEN = os.environ.get("HALOS_INFLUX_TOKEN") or ""
+
+# A racer that wins once will usually lose the next attempt; one that wins every
+# attempt is not a race we can outlast, and refusing to start is then correct.
+ATTEMPTS = 4
 
 
 def warn(msg):
@@ -63,28 +71,61 @@ def warn(msg):
 def open_dir(path, parent_fd=None):
     """Pin a directory by descriptor.
 
-    Everything below operates *at-relative to this fd, so the parent cannot be
-    swapped between one syscall and the next -- the gap no per-path check can
-    close, because each syscall otherwise re-resolves the whole path.
+    Everything below is *at-relative to this fd, so the parent cannot be swapped
+    between one syscall and the next -- the gap no per-path check can close,
+    because each syscall otherwise re-resolves the whole path.
     """
     return os.open(
         path, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW, dir_fd=parent_fd
     )
 
 
+def open_regular(dfd, name):
+    """Open an existing regular file for reading, without following or blocking.
+
+    O_NOFOLLOW refuses a symlink but not a FIFO, and a FIFO opened for reading
+    blocks until a writer appears. The type has to be checked through the
+    descriptor: checking the name first would be a different object by the time
+    the open ran.
+    """
+    fd = os.open(name, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK, dir_fd=dfd)
+    if not stat.S_ISREG(os.fstat(fd).st_mode):
+        os.close(fd)
+        raise OSError(errno.EINVAL, "not a regular file", name)
+    return fd
+
+
+def move_aside(dfd, name):
+    """Rename a wrong-type directory out of the way, to a name that is free.
+
+    A fixed destination is not free: occupying it makes every rename fail, and
+    aborting on that hands anyone who can write here a permanent boot wedge. A
+    run that already moved one aside collides with its own leftover the same way.
+    """
+    for suffix in [".unexpected"] + [
+        ".unexpected.%s" % secrets.token_hex(4) for _ in range(ATTEMPTS)
+    ]:
+        try:
+            os.rename(name, name + suffix, src_dir_fd=dfd, dst_dir_fd=dfd)
+        except FileNotFoundError:
+            return True
+        except OSError:
+            continue
+        warn("moved aside to %s%s; its contents are intact" % (name, suffix))
+        return True
+    warn("could not move %s aside; every candidate name is taken" % name)
+    return False
+
+
 def clear_unexpected(dfd, name, want_dir=False):
     """Make `name` absent or the type we need, without following anything.
 
-    Root creates only a regular file (or, for the config dir, a directory) at
-    these names. Anything else is tampering or wreckage, and the check is on
-    the *type*, not on being a symlink: a plain `mkdir` at security.json wedged
-    every boot, and a FIFO made the hook report success while streaming the
-    secrets to whoever held the read end.
+    Returns True when the name is now safe to create at -- absent, or already the
+    wanted type -- and False only when something is still in the way.
 
-    A wrong-type directory is renamed aside rather than deleted -- it may hold
-    an operator's data, and moving it both preserves that and unblocks the
-    create. Everything else (symlink, FIFO, socket, device) is something root
-    never creates here, so unlinking loses nothing.
+    Root creates only a regular file (or, for the config dir, a directory) at
+    these names, so anything else is tampering or wreckage. A wrong-type
+    directory is renamed rather than deleted: it may hold an operator's data.
     """
     try:
         st = os.lstat(name, dir_fd=dfd)
@@ -97,16 +138,15 @@ def clear_unexpected(dfd, name, want_dir=False):
     kind = "directory" if stat.S_ISDIR(st.st_mode) else (
         "symlink" if stat.S_ISLNK(st.st_mode) else "non-regular file"
     )
-    warn(f"unexpected {kind} at {name}; clearing it")
+    warn("unexpected %s at %s; clearing it" % (kind, name))
+    if stat.S_ISDIR(st.st_mode):
+        return move_aside(dfd, name)
     try:
-        if stat.S_ISDIR(st.st_mode):
-            os.rename(name, name + ".unexpected",
-                      src_dir_fd=dfd, dst_dir_fd=dfd)
-            warn(f"moved aside to {name}.unexpected; its contents are intact")
-        else:
-            os.unlink(name, dir_fd=dfd)
+        os.unlink(name, dir_fd=dfd)
+    except FileNotFoundError:
+        pass  # someone else removed it; absent is the state we wanted
     except OSError as exc:
-        warn(f"could not clear {name}: {exc}")
+        warn("could not clear %s: %s" % (name, exc))
         return False
     return True
 
@@ -114,10 +154,9 @@ def clear_unexpected(dfd, name, want_dir=False):
 def create_exclusive(dfd, name, content):
     """Create and fill `name`, refusing to follow anything.
 
-    O_EXCL|O_NOFOLLOW is a real kernel exclusive create, and the mode is applied
-    at creation so the secrets are never briefly world-readable. Bash's
-    `noclobber` is NOT equivalent: it stats first and only adds O_EXCL when that
-    stat fails, so a symlink to a FIFO or a device is followed.
+    O_EXCL|O_NOFOLLOW is a real kernel exclusive create. Bash's `noclobber` is
+    not equivalent: it stats first and only adds O_EXCL when that stat fails, so
+    a symlink to a FIFO or a device is followed.
     """
     fd = os.open(
         name,
@@ -127,34 +166,121 @@ def create_exclusive(dfd, name, content):
     )
     try:
         os.fchmod(fd, 0o600)  # explicit: the mode above is masked by umask
-        with os.fdopen(fd, "w") as f:
-            f.write(content)
     except BaseException:
         os.close(fd)
         raise
+    with os.fdopen(fd, "w") as f:  # owns fd from here, including on failure
+        f.write(content)
+
+
+def create_guarded(dfd, name, content, replace=False):
+    """Clear the name and create it, conceding only after losing repeatedly.
+
+    O_EXCL turns a lost race into EEXIST instead of a write through whatever was
+    planted, which is the point. Treating that EEXIST as fatal would hand the
+    same racer an ExecStartPre failure on demand, so the loss costs a retry.
+
+    `replace` is for a value being regenerated rather than created once: the old
+    file is a stale copy of a secret that no longer opens anything, so it goes.
+    Without it the O_EXCL create would fail against the hook's own last run.
+    """
+    for _ in range(ATTEMPTS):
+        if not clear_unexpected(dfd, name):
+            return False
+        if replace:
+            try:
+                os.unlink(name, dir_fd=dfd)
+            except FileNotFoundError:
+                pass
+            except OSError as exc:
+                warn("could not replace %s: %s" % (name, exc))
+                return False
+        try:
+            create_exclusive(dfd, name, content)
+            return True
+        except FileExistsError:
+            warn("%s reappeared between the clear and the create; retrying" % name)
+    return False
 
 
 def converge_mode(dfd, name):
     """Restrict an existing file without re-resolving its path.
 
-    chmod(2) always dereferences and has no --no-dereference, so the only safe
-    form is to open the file O_NOFOLLOW and fchmod the descriptor.
+    Failing to tighten a mode warrants a warning, never a refusal to boot: on a
+    read-only filesystem, which is how a worn SD card fails, nothing can be
+    redirected anywhere either.
     """
     try:
-        fd = os.open(name, os.O_RDONLY | os.O_NOFOLLOW, dir_fd=dfd)
-    except (FileNotFoundError, OSError):
+        fd = open_regular(dfd, name)
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        warn("could not open %s to check its mode: %s" % (name, exc))
         return
     try:
         os.fchmod(fd, 0o600)
+    except OSError as exc:
+        warn("could not tighten the mode on %s: %s" % (name, exc))
     finally:
         os.close(fd)
 
 
-# --- security.json -----------------------------------------------------------
-# Failure here aborts the hook. A Signal K with no security configuration is
-# not a degraded install, it is an open one, and the causes that remain after
-# the type check above are real filesystem faults rather than anything the
-# container can arrange.
+def configure_influx(sk_fd, token):
+    """Point the logging plugin at InfluxDB. Never fatal; see the call site."""
+    if not clear_unexpected(sk_fd, "plugin-config-data", want_dir=True):
+        warn("cannot make plugin-config-data safe to write; skipping")
+        return
+    try:
+        os.mkdir("plugin-config-data", 0o755, dir_fd=sk_fd)
+    except FileExistsError:
+        pass
+
+    cfg_fd = open_dir("plugin-config-data", parent_fd=sk_fd)
+    try:
+        name = "signalk-to-influxdb2.json"
+        if not clear_unexpected(cfg_fd, name):
+            warn("cannot make %s safe to write; skipping" % name)
+            return
+
+        converge_mode(cfg_fd, name)
+        try:
+            fd = open_regular(cfg_fd, name)
+        except FileNotFoundError:
+            if create_guarded(cfg_fd, name, json.dumps({
+                "enabled": True,
+                "configuration": {"influxes": [{
+                    "url": "http://localhost:8086",
+                    "token": token,
+                    "org": "marine",
+                    "bucket": "marine",
+                    "onlySelf": True,
+                    "resolution": 1000,
+                }]},
+            }, indent=2) + "\n"):
+                print("InfluxDB plugin configured")
+            return
+
+        # Read through the descriptor, not the path: json.load on a re-planted
+        # symlink would copy a root-only file out, and os.replace would then
+        # leave it here owned by uid 1000.
+        with os.fdopen(fd) as f:
+            cfg = json.load(f)
+        if not isinstance(cfg, dict):
+            raise ValueError("config is a %s, not an object" % type(cfg).__name__)
+        influxes = cfg.get("configuration", {}).get("influxes", [])
+        if influxes:
+            influxes[0]["token"] = token
+
+        tmp = name + ".tmp"
+        if not create_guarded(cfg_fd, tmp, json.dumps(cfg, indent=2) + "\n"):
+            warn("cannot write %s; leaving the config alone" % tmp)
+            return
+        os.replace(tmp, name, src_dir_fd=cfg_fd, dst_dir_fd=cfg_fd)
+        print("InfluxDB plugin token updated")
+    finally:
+        os.close(cfg_fd)
+
+
 sk_fd = open_dir(SK_DATA)
 root_fd = open_dir(DATA_ROOT)
 
@@ -163,91 +289,49 @@ if not clear_unexpected(sk_fd, "security.json"):
 
 converge_mode(sk_fd, "security.json")
 
+# A regular file here means an existing install. Testing only for existence
+# would accept whatever a racer left after the clear above -- a FIFO at this name
+# is not a security configuration, and skipping the create branch on account of
+# it starts Signal K with none.
 try:
-    os.lstat("security.json", dir_fd=sk_fd)
+    existing = stat.S_ISREG(os.lstat("security.json", dir_fd=sk_fd).st_mode)
 except FileNotFoundError:
+    existing = False
+
+if not existing:
+    import bcrypt  # only a new install hashes anything
+
     print("Creating initial security.json with default admin user...")
     password = secrets.token_hex(16)
+
+    # admin-password goes first. It is emergency access when OIDC is what broke,
+    # and it exists only in memory until it lands -- writing security.json first
+    # and failing here would make every later boot skip this branch, losing the
+    # password for the life of the device. Its parent is root-owned and outside
+    # the bind mount, but it is created the same way so the rule holds by
+    # construction rather than by luck.
+    if not create_guarded(root_fd, "admin-password", password + "\n", replace=True):
+        sys.exit("ERROR: cannot write the emergency admin password; refusing to start")
+
     hashed = bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
-    create_exclusive(sk_fd, "security.json", json.dumps({
+    if not create_guarded(sk_fd, "security.json", json.dumps({
         "strategy": "./tokensecurity",
         "users": [{"username": "admin", "type": "admin", "password": hashed}],
         "allow_readonly": True,
         "secretKey": secrets.token_hex(32),
-    }, indent=2) + "\n")
+    }, indent=2) + "\n"):
+        sys.exit("ERROR: cannot make security.json safe to write; refusing to start")
 
-    # Emergency access only; OIDC is the normal login path. Its parent is
-    # root-owned and outside the bind mount, but it is created the same way so
-    # the rule holds by construction rather than by luck.
-    clear_unexpected(root_fd, "admin-password")
-    try:
-        os.unlink("admin-password", dir_fd=root_fd)
-    except FileNotFoundError:
-        pass
-    create_exclusive(root_fd, "admin-password", password + "\n")
     print("Security initialized with admin user.")
-    print(f"NOTE: Local admin password stored in {DATA_ROOT}/admin-password")
+    print("NOTE: Local admin password stored in %s/admin-password" % DATA_ROOT)
     print("This is a fallback for emergency access. Use OIDC for regular login.")
 
-# --- InfluxDB plugin config --------------------------------------------------
-# Failure here only warns. Logging is not navigation, and the alternative is a
-# unit that never starts.
+# Logging is not navigation: a failure here must not cost the boot.
 if INFLUX_TOKEN:
-    if clear_unexpected(sk_fd, "plugin-config-data", want_dir=True):
-        try:
-            os.mkdir("plugin-config-data", 0o755, dir_fd=sk_fd)
-        except FileExistsError:
-            pass
-        try:
-            cfg_fd = open_dir("plugin-config-data", parent_fd=sk_fd)
-        except OSError as exc:
-            cfg_fd = None
-            warn(f"cannot open plugin-config-data: {exc}")
-
-        if cfg_fd is not None:
-            name = "signalk-to-influxdb2.json"
-            if clear_unexpected(cfg_fd, name):
-                converge_mode(cfg_fd, name)
-                try:
-                    fd = os.open(name, os.O_RDONLY | os.O_NOFOLLOW,
-                                 dir_fd=cfg_fd)
-                except FileNotFoundError:
-                    create_exclusive(cfg_fd, name, json.dumps({
-                        "enabled": True,
-                        "configuration": {"influxes": [{
-                            "url": "http://localhost:8086",
-                            "token": INFLUX_TOKEN,
-                            "org": "marine",
-                            "bucket": "marine",
-                            "onlySelf": True,
-                            "resolution": 1000,
-                        }]},
-                    }, indent=2) + "\n")
-                    print("InfluxDB plugin configured")
-                else:
-                    # Read through the descriptor, not the path: json.load on a
-                    # re-planted symlink would copy a root-only file out, and
-                    # os.replace would then leave it here owned by uid 1000.
-                    try:
-                        with os.fdopen(fd) as f:
-                            cfg = json.load(f)
-                        influxes = cfg.get("configuration", {}).get("influxes", [])
-                        if influxes:
-                            influxes[0]["token"] = INFLUX_TOKEN
-                        tmp = name + ".tmp"
-                        clear_unexpected(cfg_fd, tmp)
-                        try:
-                            os.unlink(tmp, dir_fd=cfg_fd)
-                        except FileNotFoundError:
-                            pass
-                        create_exclusive(cfg_fd, tmp,
-                                         json.dumps(cfg, indent=2) + "\n")
-                        os.replace(tmp, name,
-                                   src_dir_fd=cfg_fd, dst_dir_fd=cfg_fd)
-                        print("InfluxDB plugin token updated")
-                    except (OSError, ValueError) as exc:
-                        warn(f"failed to update InfluxDB token: {exc}")
-            os.close(cfg_fd)
+    try:
+        configure_influx(sk_fd, INFLUX_TOKEN)
+    except Exception as exc:
+        warn("InfluxDB plugin config not updated: %s" % exc)
 
 os.close(sk_fd)
 os.close(root_fd)
@@ -280,15 +364,27 @@ fi
 # data root walks the whole plugin tree on every boot.
 # -h throughout: these live in a directory the container can write, so following
 # a symlink would let it choose which host path root hands over.
-chown -h 1000:1000 "${SIGNALK_DATA}"
+#
+# Each of these tests a path and then chowns it as a separate command, in a
+# directory the container owns. Removing the file in between makes chown exit
+# non-zero, and under the framework's set -e that is an ExecStartPre failure --
+# so a vanished path warns rather than taking the navigation server down. A path
+# that is gone needs no chown.
+hand_over() {  # $1 = path, $2... = extra chown flags
+    local path="$1"; shift
+    chown -h "$@" 1000:1000 "${path}" ||
+        echo "WARNING: could not hand ${path} to the container"
+}
+
+hand_over "${SIGNALK_DATA}"
 # Unconditional, not inside a create branch: the python block above may have
 # created security.json on this run or on any earlier one, and the container
 # cannot log anyone in through a file it does not own.
 if [ -f "${SECURITY_FILE}" ]; then
-    chown -h 1000:1000 "${SECURITY_FILE}"
+    hand_over "${SECURITY_FILE}"
 fi
 if [ -f "${SIGNALK_DATA}/settings.json" ]; then
-    chown -h 1000:1000 "${SIGNALK_DATA}/settings.json"
+    hand_over "${SIGNALK_DATA}/settings.json"
 fi
 
 # The app store installs plugin updates into this tree as uid 1000, and that is
@@ -315,13 +411,13 @@ fi
 # that does not exist is itself non-zero -- turning "the server runs, plugin
 # updates are broken" back into "the server never starts".
 if mkdir -p "${SIGNALK_DATA}/node_modules"; then
-    chown -h 1000:1000 "${SIGNALK_DATA}/node_modules"
+    hand_over "${SIGNALK_DATA}/node_modules"
 else
     echo "WARNING: could not create ${SIGNALK_DATA}/node_modules; plugin updates will fail"
 fi
 if [ -f "${SIGNALK_DATA}/package.json" ]; then
-    chown -h 1000:1000 "${SIGNALK_DATA}/package.json"
+    hand_over "${SIGNALK_DATA}/package.json"
 fi
 if [ -d "${PLUGIN_CONFIG_DIR}" ]; then
-    chown -Rh 1000:1000 "${PLUGIN_CONFIG_DIR}"
+    hand_over "${PLUGIN_CONFIG_DIR}" -R
 fi

--- a/apps/signalk-server/prestart.sh
+++ b/apps/signalk-server/prestart.sh
@@ -33,10 +33,17 @@ mkdir -p "${SIGNALK_DATA}"
 # framework sources this under set -e, so a non-zero return here withholds the
 # app -- the correct outcome when the alternative is root writing to a path the
 # container chose.
-drop_symlink() {
+drop_symlink() {  # $1 = path, $2 = optional consequence to warn about
     [ -L "$1" ] || return 0
     echo "WARNING: removing unexpected symlink at $1"
-    rm -f "$1" || {
+    [ -n "${2:-}" ] && echo "WARNING: $2"
+    # -rf rather than -f: between the test above and this line the path can turn
+    # into a real directory, which rm -f refuses -- and a non-zero return here
+    # withholds the app on every boot until someone runs reset-failed by hand.
+    # Root can always clear a path whose parent it owns, so give it the chance
+    # before failing. Only a path that was a symlink a moment ago reaches this,
+    # so nothing an operator put here deliberately is at risk.
+    rm -rf "$1" || {
         echo "ERROR: could not remove ${1}; refusing to write through it"
         return 1
     }
@@ -44,7 +51,8 @@ drop_symlink() {
 # Parent before child: clearing a symlinked directory changes what the paths
 # below it resolve to.
 drop_symlink "${PLUGIN_CONFIG_DIR}"
-drop_symlink "${SECURITY_FILE}"
+drop_symlink "${SECURITY_FILE}" \
+    "a fresh security.json follows: the admin password and the JWT signing key are regenerated, so existing tokens and device approvals stop validating, and whatever the link pointed at is left where it is"
 drop_symlink "${PLUGIN_CONFIG}"
 
 # Earlier versions created both of these 0644, so every already-deployed device

--- a/run
+++ b/run
@@ -83,7 +83,7 @@ function test {
   #@ Category: Testing
   echo "🧪 Running tests..."
   docker run --rm -v "$(pwd):/workspace" -w /workspace python:3.11-slim \
-    bash -c "pip install -q pytest pyyaml && python -m pytest tests/ -v"
+    bash -c "pip install -q -r tests/requirements.txt && python -m pytest tests/ -v"
 }
 
 function test:watch {

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,6 @@
 pytest>=8.0.0
 pyyaml>=6.0
+# apps/signalk-server/prestart.sh hashes the admin password with it, and the
+# package declares python3-bcrypt as a runtime dependency. The harness does not
+# stub it: the python block that imports it is what the suite exercises.
+bcrypt>=4.0

--- a/tests/test_signalk_prestart.py
+++ b/tests/test_signalk_prestart.py
@@ -99,7 +99,7 @@ def test_prestart_is_executable():
 
 
 def test_prestart_hook_behaves():
-    """Run the hook against a sandbox with stubbed chown/bcrypt.
+    """Run the hook against a sandbox with chown stubbed.
 
     It writes the admin hash, the JWT key and the InfluxDB token. Their modes are
     a property of the filesystem after it runs, which no assertion on the

--- a/tools/test-prestart.sh
+++ b/tools/test-prestart.sh
@@ -291,14 +291,18 @@ teardown
 # container-writable. The token is the InfluxDB admin credential.
 setup
 CANARY="${SANDBOX}/outside-the-data-root"
-printf 'original\n' > "${CANARY}"; chmod 644 "${CANARY}"
+# Valid JSON on purpose. With plain text the hook's json.load raises before it
+# writes anything, so "not written through" would pass against a vulnerable hook
+# for a reason that has nothing to do with the guard.
+printf '{"configuration":{"influxes":[{"token":"none"}]}}\n' > "${CANARY}"
+chmod 644 "${CANARY}"
 mkdir -p "${SK}/plugin-config-data"
 ln -s "${CANARY}" "${SK}/plugin-config-data/signalk-to-influxdb2.json"
 influx_available tok-symlink
 check "a symlinked influx config does not wedge the unit" "$(run_hook)" "0"
-[ "$(cat "${CANARY}")" = "original" ] &&
-    ok "  no token written through the link" ||
-    bad "  no token written through the link" "$(cat "${CANARY}")"
+grep -q tok-symlink "${CANARY}" &&
+    bad "  no token written through the link" "token landed in the link target" ||
+    ok "  no token written through the link"
 check "  the link target keeps its mode" "$(mode "${CANARY}")" "644"
 check "  a real config replaces the link, 0600" \
     "$(mode "${SK}/plugin-config-data/signalk-to-influxdb2.json")" "600"

--- a/tools/test-prestart.sh
+++ b/tools/test-prestart.sh
@@ -220,6 +220,82 @@ grep -q "WARNING: could not create" "${SANDBOX}/out" &&
     ok "  and says so" || bad "  and says so" "$(cat "${SANDBOX}/out")"
 teardown
 
+# The container owns ${SIGNALK_DATA}, so it can replace any file root writes
+# there with a symlink and redirect the write. chmod, touch and cat > all
+# dereference. The canary lives outside the data root: if the hook writes
+# through the link, the canary changes, and that is a container-to-host-root
+# escalation on a real device.
+setup
+CANARY="${SANDBOX}/outside-the-data-root"
+printf 'original\n' > "${CANARY}"; chmod 644 "${CANARY}"
+ln -s "${CANARY}" "${SK}/security.json"
+check "a symlinked security.json does not wedge the unit" "$(run_hook)" "0"
+[ "$(cat "${CANARY}")" = "original" ] &&
+    ok "  the link target is not written through" ||
+    bad "  the link target is not written through" "$(cat "${CANARY}")"
+check "  the link target keeps its mode" "$(mode "${CANARY}")" "644"
+[ -f "${SK}/security.json" ] && [ ! -L "${SK}/security.json" ] &&
+    ok "  a real security.json replaces the link" ||
+    bad "  a real security.json replaces the link" "$(ls -ld "${SK}/security.json")"
+check "  and is 0600" "$(mode "${SK}/security.json")" "600"
+grep -q 'removing unexpected symlink' "${SANDBOX}/out" &&
+    ok "  the removal is logged" || bad "  the removal is logged" "$(cat "${SANDBOX}/out")"
+teardown
+
+# The full escalation needs a DANGLING link. A link to an existing file satisfies
+# [ -f ], so the hook takes its "already exists" branch and only strips the mode;
+# a link to a path that does not exist takes the create branch, where touch
+# creates the target, cat > writes the admin hash and JWT key into it, and chown
+# hands it to uid 1000. That is the /etc/ld.so.preload chain, and the assertion
+# that matters is that the target path is never created at all.
+setup
+TARGET="${SANDBOX}/does-not-exist-yet"
+ln -s "${TARGET}" "${SK}/security.json"
+check "a dangling security.json link does not wedge the unit" "$(run_hook)" "0"
+[ ! -e "${TARGET}" ] &&
+    ok "  root never creates the link target" ||
+    bad "  root never creates the link target" "created: $(ls -l "${TARGET}"; cat "${TARGET}")"
+[ -f "${SK}/security.json" ] && [ ! -L "${SK}/security.json" ] &&
+    ok "  a real security.json is created instead" ||
+    bad "  a real security.json is created instead" "$(ls -ld "${SK}/security.json")"
+grep -q secretKey "${SK}/security.json" &&
+    ok "  with the generated secrets in it" ||
+    bad "  with the generated secrets in it" "$(cat "${SK}/security.json")"
+teardown
+
+# Same attack against the InfluxDB token config, whose parent is equally
+# container-writable. The token is the InfluxDB admin credential.
+setup
+CANARY="${SANDBOX}/outside-the-data-root"
+printf 'original\n' > "${CANARY}"; chmod 644 "${CANARY}"
+mkdir -p "${SK}/plugin-config-data"
+ln -s "${CANARY}" "${SK}/plugin-config-data/signalk-to-influxdb2.json"
+influx_available tok-symlink
+check "a symlinked influx config does not wedge the unit" "$(run_hook)" "0"
+[ "$(cat "${CANARY}")" = "original" ] &&
+    ok "  no token written through the link" ||
+    bad "  no token written through the link" "$(cat "${CANARY}")"
+check "  the link target keeps its mode" "$(mode "${CANARY}")" "644"
+check "  a real config replaces the link, 0600" \
+    "$(mode "${SK}/plugin-config-data/signalk-to-influxdb2.json")" "600"
+teardown
+
+# A symlinked plugin-config-data directory redirects everything below it, so the
+# parent has to be cleared before the child path is even resolved.
+setup
+OUTSIDE="${SANDBOX}/outside-dir"
+mkdir -p "${OUTSIDE}"
+ln -s "${OUTSIDE}" "${SK}/plugin-config-data"
+influx_available tok-dirlink
+check "a symlinked plugin-config-data does not wedge the unit" "$(run_hook)" "0"
+[ ! -e "${OUTSIDE}/signalk-to-influxdb2.json" ] &&
+    ok "  nothing written into the link target" ||
+    bad "  nothing written into the link target" "$(ls -l "${OUTSIDE}")"
+[ -d "${SK}/plugin-config-data" ] && [ ! -L "${SK}/plugin-config-data" ] &&
+    ok "  a real directory replaces the link" ||
+    bad "  a real directory replaces the link" "$(ls -ld "${SK}/plugin-config-data")"
+teardown
+
 # apps/influxdb/prestart.sh has paths that leave the env file without a usable
 # token. With the plugin-presence gate gone, the emptiness check is the only
 # thing standing between that and a config naming the database with no

--- a/tools/test-prestart.sh
+++ b/tools/test-prestart.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Exercise apps/signalk-server/prestart.sh with stubbed chown/bcrypt.
+# Exercise apps/signalk-server/prestart.sh with chown stubbed.
 #
 # The hook writes three files holding secrets. Their modes are a property of the
 # filesystem after it runs, not of the script's text, so this runs it against a
@@ -57,10 +57,9 @@ for arg in "$@"; do
     }
 done
 STUB
-    # python3 is passed straight through. bcrypt used to be stubbed here, but the
-    # hook now does all its filesystem work in one python3 block that imports
-    # bcrypt directly -- and that block IS the thing under test, so intercepting
-    # it would gut the suite. bcrypt is a declared package dependency
+    # python3 is passed straight through. bcrypt is deliberately not stubbed:
+    # the python block that imports it is the thing under test, so intercepting
+    # it would gut the suite. It is a declared package dependency
     # (python3-bcrypt); install it locally to run this.
     cat > "${SANDBOX}/bin/python3" <<'STUB'
 #!/bin/bash
@@ -77,6 +76,12 @@ teardown() { rm -rf "${SANDBOX}"; }
 # would report only the last command's status, so any command that aborts the
 # real ExecStartPre -- and takes the navigation server down with it -- would look
 # like a clean exit 0 here.
+#
+# Under a timeout, because the failure this suite exists to catch can hang rather
+# than fail: opening a FIFO to read blocks until a writer appears, so a hook that
+# leaves one in place stops here forever instead of reporting anything. A hang is
+# an ExecStartPre that never returns, which is a failure and should read as one.
+TIMEOUT="$(command -v timeout || command -v gtimeout || true)"
 run_hook() {  # echoes exit status
     PATH="${SANDBOX}/bin:${PATH}" \
         CONTAINER_DATA_ROOT="${DATA}" \
@@ -84,6 +89,7 @@ run_hook() {  # echoes exit status
         HALOS_DOMAIN="test.local" \
         INFLUXDB_ENV="${SANDBOX}/influxdb.env" \
         PYTHONPATH="${SANDBOX}/pylib" \
+        ${TIMEOUT:+"${TIMEOUT}" -s KILL 20} \
         bash -c 'set -e; . "$1"' _ "${HOOK}" > "${SANDBOX}/out" 2>&1
     echo $?
 }
@@ -118,6 +124,25 @@ chowned() {  # $1 = path the hook must have handed to the container uid
             if (owner && noderef && path) f = 0
         }
         END { exit f }' "${STUB_LOG}"
+}
+
+# Plants a hostile object at the instant before the hook opens a path, which is
+# the window every guard here exists for. A bcrypt shim used to serve this and
+# cannot any more: the clear happens inside the create, after the hash, so
+# anything planted from bcrypt lands *before* the clear and is simply removed --
+# which is how the two racer scenarios silently became no-ops. Wrapping os.open
+# is inside the window by construction, and stays there if the order changes.
+inject_before_open() {  # $1 = True for the create, False for the read; $2 = sh
+    cat > "${SANDBOX}/pylib/sitecustomize.py" <<SHIM
+import os, subprocess
+_real, _fired = os.open, []
+def _open(path, flags, mode=0o777, *, dir_fd=None):
+    if path == "security.json" and not _fired and bool(flags & os.O_CREAT) is ${1}:
+        _fired.append(True)
+        subprocess.run(["sh", "-c", r"""${2}"""])
+    return _real(path, flags, mode, dir_fd=dir_fd)
+os.open = _open
+SHIM
 }
 
 echo "prestart.sh behaviour"
@@ -239,85 +264,64 @@ grep -q secretKey "${SK}/security.json" 2>/dev/null &&
 teardown
 
 # Everything above plants its hostile object BEFORE the hook runs, where the type
-# check clears it -- so none of it exercises O_EXCL. This one plants from INSIDE
-# the run, which is the only condition O_EXCL exists for.
+# check clears it -- so none of it exercises O_EXCL. These plant in the window
+# between the clear and the create, which is the only condition O_EXCL exists for.
 #
-# The hook hashes the admin password between clearing the path and creating it,
-# so a bcrypt shim on PYTHONPATH fires in exactly that window -- deterministic,
-# no sleeps, no spin loop. Reverting the create to O_TRUNC, to open(,'w'), or to
-# touch+chmod+cat must fail this.
+# The status is asserted, not discarded. O_EXCL refusing the write and python
+# dying before it reaches the write leave a canary equally untouched, so a test
+# that only reads the canary cannot tell a working guard from a crash -- and the
+# crash is itself an ExecStartPre abort the racer can repeat until systemd gives
+# up on the unit.
 setup
 CANARY="${SANDBOX}/outside-the-data-root"
 printf 'original\n' > "${CANARY}"; chmod 644 "${CANARY}"
-cat > "${SANDBOX}/pylib/bcrypt.py" <<SHIM
-import os
-def gensalt(*a, **k):
-    return b"\$2b\$12\$stubsaltstubsaltstubsa"
-def hashpw(pw, salt):
-    # the racer wins the window: the path was just cleared, so this succeeds
-    os.symlink("${CANARY}", "${SK}/security.json")
-    return b"\$2b\$12\$stubhashstubhashstubhashstubhashstubhas"
-SHIM
-run_hook > /dev/null 2>&1
+inject_before_open True "ln -sfn '${CANARY}' '${SK}/security.json'"
+check "a symlink planted after the clear does not wedge the unit" "$(run_hook)" "0"
 [ "$(cat "${CANARY}")" = "original" ] &&
-    ok "a symlink planted after the clear is not written through" ||
-    bad "a symlink planted after the clear is not written through" "$(cat "${CANARY}")"
+    ok "  the link target is not written through" ||
+    bad "  the link target is not written through" "$(cat "${CANARY}")"
 check "  and the link target keeps its mode" "$(mode "${CANARY}")" "644"
+[ -f "${SK}/security.json" ] && [ ! -L "${SK}/security.json" ] &&
+    ok "  a real security.json is created instead" ||
+    bad "  a real security.json is created instead" "$(ls -ld "${SK}/security.json" 2>&1)"
 teardown
 
-# A plain directory at a guarded path was a race-free boot wedge: the old guard
-# only fired on [ -L ], so cat > failed "Is a directory" on every single boot and
-# five of those put the unit in `failed`. One mkdir from uid 1000 was enough.
+# A symlink is refused by O_EXCL and by O_NOFOLLOW alike, so the scenario above
+# pins neither on its own. A FIFO is not a symlink: O_NOFOLLOW lets it through
+# and only O_EXCL refuses it. This is the scenario that pins O_EXCL by itself.
+#
+# The assertion is the post-state, not a reader's capture: uid 1000 is meant to
+# read security.json once it is handed over, so "a reader saw bytes" is true in
+# the healthy case too. What a FIFO costs is the file -- the write goes into the
+# pipe, or blocks with no reader, and security.json is never created.
 setup
-mkdir -p "${SK}/security.json"
-check "a directory at security.json does not wedge the unit" "$(run_hook)" "0"
-[ -f "${SK}/security.json" ] && [ ! -d "${SK}/security.json" ] &&
-    ok "  a real security.json is created" ||
-    bad "  a real security.json is created" "$(ls -ld "${SK}/security.json")"
-[ -d "${SK}/security.json.unexpected" ] &&
-    ok "  the directory is moved aside, not deleted" ||
-    bad "  the directory is moved aside, not deleted" "no .unexpected directory"
-teardown
-
-# A FIFO is the case bash's noclobber silently followed: with a reader attached
-# the old hook logged "Security initialized", wrote nothing to disk, and streamed
-# the admin hash and JWT signing key to whoever held the read end.
-setup
-mkfifo "${SK}/security.json"
-( timeout 10 cat "${SK}/security.json" > "${SANDBOX}/leak" 2>/dev/null & )
-check "a FIFO at security.json does not leak the secrets" "$(run_hook)" "0"
-sleep 0.3
-[ ! -s "${SANDBOX}/leak" ] &&
-    ok "  nothing was streamed to the reader" ||
-    bad "  nothing was streamed to the reader" "$(head -c 120 "${SANDBOX}/leak")"
+inject_before_open True "rm -f '${SK}/security.json'; mkfifo '${SK}/security.json'"
+check "a FIFO planted after the clear does not wedge the unit" "$(run_hook)" "0"
 [ -f "${SK}/security.json" ] && [ ! -p "${SK}/security.json" ] &&
-    ok "  a real security.json replaces it" ||
-    bad "  a real security.json replaces it" "$(ls -ld "${SK}/security.json")"
-grep -q secretKey "${SK}/security.json" 2>/dev/null &&
-    ok "  with the secrets on disk where they belong" ||
-    bad "  with the secrets on disk where they belong" "$(cat "${SK}/security.json" 2>&1)"
+    ok "  a real security.json is created, not written into the pipe" ||
+    bad "  a real security.json is created, not written into the pipe" \
+        "$(ls -ld "${SK}/security.json" 2>&1)"
+# Guarded on -f: if the hook left the FIFO in place, this grep would open it for
+# reading and block until a writer appears, hanging the suite instead of failing
+# the assertion above it.
+[ -f "${SK}/security.json" ] && grep -q secretKey "${SK}/security.json" 2>/dev/null &&
+    ok "  with the secrets in it" ||
+    bad "  with the secrets in it" "$(ls -ld "${SK}/security.json" 2>&1)"
 teardown
 
-# Everything above plants its hostile object BEFORE the hook runs, where the type
-# check clears it -- so none of it exercises O_EXCL. This one re-plants from
-# inside the run, which is the only condition O_EXCL exists for. Reverting the
-# create to open(,'w') or to touch+chmod+cat must fail here.
+# The same window on the read side. converge_mode opens an existing security.json
+# to tighten its mode, and O_NOFOLLOW does not refuse a FIFO -- an O_RDONLY open
+# of one blocks until a writer appears, which for ExecStartPre means hanging
+# until TimeoutStartSec on every boot the racer chooses.
 setup
-CANARY="${SANDBOX}/outside-the-data-root"
-printf 'original\n' > "${CANARY}"; chmod 644 "${CANARY}"
-cat > "${SANDBOX}/bin/openssl" <<STUB
-#!/bin/bash
-# stands in for a uid-1000 process winning the window after the clear
-ln -sfn "${CANARY}" "${SK}/security.json"
-exec /usr/bin/openssl "\$@"
-STUB
-chmod 755 "${SANDBOX}/bin/openssl"
-run_hook > /dev/null 2>&1
-[ "$(cat "${CANARY}")" = "original" ] &&
-    ok "a symlink planted after the clear is not written through" ||
-    bad "a symlink planted after the clear is not written through" "$(cat "${CANARY}")"
-check "  and the link target keeps its mode" "$(mode "${CANARY}")" "644"
+printf '{"users":[]}\n' > "${SK}/security.json"
+inject_before_open False "rm -f '${SK}/security.json'; mkfifo '${SK}/security.json'"
+check "a FIFO planted before the mode check does not hang the boot" "$(run_hook)" "0"
+[ -f "${SK}/security.json" ] && [ ! -p "${SK}/security.json" ] &&
+    ok "  and a real security.json replaces it" ||
+    bad "  and a real security.json replaces it" "$(ls -ld "${SK}/security.json" 2>&1)"
 teardown
+
 
 # A full data partition is the realistic trigger: mkdir needs a block, the chmods
 # on existing files above do not. Signal K must still come up -- plugin updates
@@ -472,6 +476,173 @@ grep -q '"secretKey": *"old"' "${SK}/security.json" &&
 grep -q tok-rotated "${SK}/plugin-config-data/signalk-to-influxdb2.json" &&
     ok "  influx token is refreshed" ||
     bad "  influx token is refreshed" "$(cat "${SK}/plugin-config-data/signalk-to-influxdb2.json")"
+teardown
+
+# Refusing to start is the right answer when the path cannot be made safe, so the
+# cases below are not about softening that. They are about the abort firing when
+# nothing is actually wrong -- an abort the container can trigger on demand, or a
+# disk fault that redirects nothing, is a permanent outage bought for nothing.
+# ExecStartPre has no restart budget to spare: five failures and the unit is
+# `failed` until someone reaches the boat.
+
+# The move-aside picks a fixed name, so occupying that name makes the clear fail
+# and the hook refuse to start -- on every boot, from two commands. It also
+# happens with no attacker: run N moves a directory aside, run N+1 finds another
+# one and collides with its own leftover.
+setup
+mkdir -p "${SK}/security.json"
+: > "${SK}/security.json.unexpected"
+check "an occupied .unexpected name does not wedge the unit" "$(run_hook)" "0"
+[ -f "${SK}/security.json" ] && [ ! -d "${SK}/security.json" ] &&
+    ok "  a real security.json replaces the directory" ||
+    bad "  a real security.json replaces the directory" "$(ls -ld "${SK}/security.json" 2>&1)"
+teardown
+
+# The InfluxDB section documents itself as warn-only. uid 1000 owns this file --
+# the hook hands it over on every run -- and any valid JSON that is not an object
+# makes .get() raise, which `except (OSError, ValueError)` does not catch.
+for payload in '[]' 'null' '42' '"str"'; do
+    setup
+    influx_available "tok-abc"
+    mkdir -p "${SK}/plugin-config-data"
+    printf '%s' "${payload}" > "${SK}/plugin-config-data/signalk-to-influxdb2.json"
+    check "an influx config of ${payload} warns instead of blocking start" "$(run_hook)" "0"
+    teardown
+done
+
+# admin-password is the documented way back in when OIDC is what broke. It is
+# written after security.json, and the password exists only in memory in between,
+# so a failure there loses it for the life of the device: every later boot sees
+# security.json and skips the whole create branch.
+setup
+chmod 555 "${DATA}"
+run_hook > /dev/null 2>&1
+chmod 755 "${DATA}"
+check "a failed admin-password write leaves nothing half-created" "$(run_hook)" "0"
+[ -s "${DATA}/admin-password" ] &&
+    ok "  the emergency password is written on the retry" ||
+    bad "  the emergency password is written on the retry" "$(ls -l "${DATA}/admin-password" 2>&1)"
+teardown
+
+# bcrypt is only needed to hash a new password. A device whose security.json was
+# written years ago needs none of it, and an interrupted upgrade is exactly how a
+# boat ends up with a half-configured python3.
+setup
+printf '{"users":[]}\n' > "${SK}/security.json"
+printf 'raise ImportError("python3-bcrypt is broken here")\n' > "${SANDBOX}/pylib/bcrypt.py"
+check "a broken bcrypt does not wedge an already-configured device" "$(run_hook)" "0"
+teardown
+
+# A worn SD card fails by remounting read-only, and ext4 does it mid-run. Nothing
+# can be redirected anywhere on a read-only filesystem, so failing to tighten a
+# mode there is not a reason to leave the vessel without a navigation server.
+setup
+printf '{"users":[]}\n' > "${SK}/security.json"
+chmod 644 "${SK}/security.json"
+cat > "${SANDBOX}/pylib/sitecustomize.py" <<'SHIM'
+import errno, os
+def _fchmod(fd, mode):
+    raise OSError(errno.EROFS, "Read-only file system")
+os.fchmod = _fchmod
+SHIM
+check "a read-only filesystem does not stop the server starting" "$(run_hook)" "0"
+grep -q "WARNING" "${SANDBOX}/out" &&
+    ok "  and the failure is logged" || bad "  and the failure is logged" "$(cat "${SANDBOX}/out")"
+teardown
+
+
+# Pinning the parent by descriptor is the stated reason for doing this in python
+# at all, and nothing above tests it: every hostile parent is planted before the
+# run, where the type check clears it and the descriptor never matters. Here the
+# directory is swapped *after* open_dir returned, which is the only condition
+# dir_fd exists for. Re-resolving these paths instead writes the token into the
+# attacker's directory.
+setup
+influx_available "tok-pinned"
+cat > "${SANDBOX}/pylib/sitecustomize.py" <<SHIM
+import os
+_real_open, _swapped = os.open, []
+def _open(path, flags, mode=0o777, *, dir_fd=None):
+    fd = _real_open(path, flags, mode, dir_fd=dir_fd)
+    # basename, so the swap still lands if the code under test resolves the
+    # whole path instead of going through the parent descriptor -- which is the
+    # regression this scenario exists to catch.
+    if os.path.basename(path) == "plugin-config-data" and not _swapped:
+        _swapped.append(True)
+        os.rename("${SK}/plugin-config-data", "${SK}/pinned-dir")
+        os.mkdir("${SK}/decoy-dir")
+        os.symlink("${SK}/decoy-dir", "${SK}/plugin-config-data")
+    return fd
+os.open = _open
+SHIM
+check "a parent swapped after it was opened does not redirect the write" "$(run_hook)" "0"
+[ -f "${SK}/pinned-dir/signalk-to-influxdb2.json" ] &&
+    ok "  the config lands in the directory that was opened" ||
+    bad "  the config lands in the directory that was opened" "$(ls -a "${SK}/pinned-dir" 2>&1)"
+[ ! -e "${SK}/decoy-dir/signalk-to-influxdb2.json" ] &&
+    ok "  and not in the one swapped in behind it" ||
+    bad "  and not in the one swapped in behind it" "$(ls -a "${SK}/decoy-dir" 2>&1)"
+teardown
+
+# admin-password is only useful if it opens the account whose hash is in
+# security.json. Writing the hash to both, or regenerating the password on every
+# boot while security.json keeps the first hash, leaves every mode and ownership
+# assertion above satisfied and emergency access dead -- discovered when OIDC is
+# already broken and this is the way back in.
+setup
+run_hook > /dev/null
+"${REAL_PYTHON3}" -c '
+import bcrypt, json, sys
+pw = open(sys.argv[1], "rb").read().strip()
+hashed = json.load(open(sys.argv[2]))["users"][0]["password"].encode()
+sys.exit(0 if bcrypt.checkpw(pw, hashed) else 1)
+' "${DATA}/admin-password" "${SK}/security.json" 2>/dev/null &&
+    ok "admin-password opens the admin account in security.json" ||
+    bad "admin-password opens the admin account in security.json" \
+        "$(head -c 60 "${DATA}/admin-password" 2>&1)"
+# The emergency password must survive an ordinary restart: rewriting it while
+# security.json keeps the old hash silently breaks the fallback.
+BEFORE="$(cat "${DATA}/admin-password")"
+run_hook > /dev/null
+check "  and is not rewritten on the next boot" "$(cat "${DATA}/admin-password")" "${BEFORE}"
+teardown
+
+# The emergency password's protection is that root owns its parent. A chown of it
+# to the container uid would hand over the one credential that is supposed to
+# outlive a compromise, and nothing above would notice.
+setup
+influx_available "tok-chown"
+run_hook > /dev/null
+chowned "${DATA}/admin-password" &&
+    bad "admin-password is not handed to the container" "it was chowned to 1000:1000" ||
+    ok "admin-password is not handed to the container"
+chowned "${SK}/plugin-config-data" &&
+    ok "plugin-config-data is handed over" ||
+    bad "plugin-config-data is handed over" "$(cat "${STUB_LOG}")"
+teardown
+
+setup
+: > "${SK}/settings.json"
+run_hook > /dev/null
+chowned "${SK}/settings.json" &&
+    ok "settings.json is handed over" ||
+    bad "settings.json is handed over" "$(cat "${STUB_LOG}")"
+teardown
+
+# Every other scenario asserts the hook exits 0, so nothing pins the deliberate
+# refusal. Replacing it with a warning would start Signal K with no security
+# configuration -- open, not degraded -- with the suite green. An unwritable
+# parent is a fault the hook genuinely cannot clear.
+setup
+mkdir -p "${SK}/security.json"
+chmod 555 "${SK}"
+STATUS="$(run_hook)"
+chmod 755 "${SK}"
+[ "${STATUS}" != "0" ] &&
+    ok "an unclearable security.json refuses to start" ||
+    bad "an unclearable security.json refuses to start" "exited 0"
+grep -q "refusing to start" "${SANDBOX}/out" &&
+    ok "  and says why" || bad "  and says why" "$(cat "${SANDBOX}/out")"
 teardown
 
 # The hook is sourced by the generated prestart, so a false test at the end of it

--- a/tools/test-prestart.sh
+++ b/tools/test-prestart.sh
@@ -125,6 +125,9 @@ echo "prestart.sh behaviour"
 setup
 check "fresh install exits 0" "$(run_hook)" "0"
 check "  security.json is 0600" "$(mode "${SK}/security.json")" "600"
+chowned "${SK}/security.json" &&
+    ok "  security.json handed over with -h" ||
+    bad "  security.json handed over with -h" "$(cat "${STUB_LOG}")"
 check "  admin-password is 0600" "$(mode "${DATA}/admin-password")" "600"
 teardown
 
@@ -200,6 +203,27 @@ ln -s "${SANDBOX}/elsewhere" "${SK}/node_modules"
 check "a relocated node_modules is left in place" "$(run_hook)" "0"
 [ -L "${SK}/node_modules" ] &&
     ok "  the symlink survives" || bad "  the symlink survives" "symlink was replaced"
+teardown
+
+# The one path in this hook that deliberately takes the unit down. If the symlink
+# cannot be removed, writing through it is worse than not starting -- but that
+# tradeoff is only defensible if it actually happens, so pin it.
+setup
+ln -s /nonexistent "${SK}/security.json"
+cat > "${SANDBOX}/bin/rm" <<'STUB'
+#!/bin/bash
+for arg in "$@"; do
+    case "$arg" in */security.json) echo "rm: cannot remove" >&2; exit 1 ;; esac
+done
+exec /bin/rm "$@"
+STUB
+chmod 755 "${SANDBOX}/bin/rm"
+st=$(run_hook)
+[ "$st" != "0" ] &&
+    ok "an unremovable symlink withholds the app rather than writing through" ||
+    bad "an unremovable symlink withholds the app rather than writing through" "exit 0"
+grep -q 'refusing to write through it' "${SANDBOX}/out" &&
+    ok "  and says why" || bad "  and says why" "$(cat "${SANDBOX}/out")"
 teardown
 
 # A full data partition is the realistic trigger: mkdir needs a block, the chmods
@@ -278,6 +302,28 @@ check "a symlinked influx config does not wedge the unit" "$(run_hook)" "0"
 check "  the link target keeps its mode" "$(mode "${CANARY}")" "644"
 check "  a real config replaces the link, 0600" \
     "$(mode "${SK}/plugin-config-data/signalk-to-influxdb2.json")" "600"
+teardown
+
+# The token-rewrite branch writes a sibling temp file, and plugin-config-data is
+# chowned to uid 1000 on every run -- so the container can plant the .tmp path as
+# a symlink and redirect root's write through a path the guard never names. Needs
+# an existing config so the run takes the update branch rather than the create.
+setup
+CANARY="${SANDBOX}/outside-the-data-root"
+printf 'original\n' > "${CANARY}"; chmod 644 "${CANARY}"
+mkdir -p "${SK}/plugin-config-data"
+printf '{"configuration":{"influxes":[{"token":"stale"}]}}\n' \
+    > "${SK}/plugin-config-data/signalk-to-influxdb2.json"
+ln -s "${CANARY}" "${SK}/plugin-config-data/signalk-to-influxdb2.json.tmp"
+influx_available tok-tmplink
+check "a symlinked .tmp does not redirect the token rewrite" "$(run_hook)" "0"
+[ "$(cat "${CANARY}")" = "original" ] &&
+    ok "  the link target is not written through" ||
+    bad "  the link target is not written through" "$(cat "${CANARY}")"
+check "  the link target keeps its mode" "$(mode "${CANARY}")" "644"
+grep -q tok-tmplink "${SK}/plugin-config-data/signalk-to-influxdb2.json" &&
+    ok "  and the real config still gets the token" ||
+    bad "  and the real config still gets the token" "$(cat "${SK}/plugin-config-data/signalk-to-influxdb2.json")"
 teardown
 
 # A symlinked plugin-config-data directory redirects everything below it, so the

--- a/tools/test-prestart.sh
+++ b/tools/test-prestart.sh
@@ -36,7 +36,7 @@ setup() {
     SANDBOX="$(mktemp -d)"
     DATA="${SANDBOX}/data"
     SK="${DATA}/data"
-    mkdir -p "${SK}" "${SANDBOX}/bin"
+    mkdir -p "${SK}" "${SANDBOX}/bin" "${SANDBOX}/pylib"
     STUB_LOG="${SANDBOX}/chown.log"; : > "${STUB_LOG}"
     export STUB_LOG
 
@@ -57,14 +57,13 @@ for arg in "$@"; do
     }
 done
 STUB
-    # bcrypt is not installed on a dev machine; every other python3 call is real.
+    # python3 is passed straight through. bcrypt used to be stubbed here, but the
+    # hook now does all its filesystem work in one python3 block that imports
+    # bcrypt directly -- and that block IS the thing under test, so intercepting
+    # it would gut the suite. bcrypt is a declared package dependency
+    # (python3-bcrypt); install it locally to run this.
     cat > "${SANDBOX}/bin/python3" <<'STUB'
 #!/bin/bash
-if [ "${1:-}" = "-c" ] && [[ "${2:-}" == *bcrypt* ]]; then
-    cat >/dev/null
-    echo '$2b$12$stubhashstubhashstubhashstubhashstubhas'
-    exit 0
-fi
 exec "${REAL_PYTHON3}" "$@"
 STUB
     chmod 755 "${SANDBOX}/bin"/*
@@ -84,6 +83,7 @@ run_hook() {  # echoes exit status
         RUNTIME_ENV="${SANDBOX}/runtime.env" \
         HALOS_DOMAIN="test.local" \
         INFLUXDB_ENV="${SANDBOX}/influxdb.env" \
+        PYTHONPATH="${SANDBOX}/pylib" \
         bash -c 'set -e; . "$1"' _ "${HOOK}" > "${SANDBOX}/out" 2>&1
     echo $?
 }
@@ -205,25 +205,118 @@ check "a relocated node_modules is left in place" "$(run_hook)" "0"
     ok "  the symlink survives" || bad "  the symlink survives" "symlink was replaced"
 teardown
 
-# The one path in this hook that deliberately takes the unit down. If the symlink
-# cannot be removed, writing through it is worse than not starting -- but that
-# tradeoff is only defensible if it actually happens, so pin it.
+# A plain directory at a guarded path was a race-free boot wedge: the old guard
+# only fired on [ -L ], so cat > failed "Is a directory" on every single boot and
+# five of those put the unit in `failed`. One mkdir from uid 1000 was enough.
 setup
-ln -s /nonexistent "${SK}/security.json"
-cat > "${SANDBOX}/bin/rm" <<'STUB'
+mkdir -p "${SK}/security.json"
+check "a directory at security.json does not wedge the unit" "$(run_hook)" "0"
+[ -f "${SK}/security.json" ] && [ ! -d "${SK}/security.json" ] &&
+    ok "  a real security.json is created" ||
+    bad "  a real security.json is created" "$(ls -ld "${SK}/security.json")"
+[ -d "${SK}/security.json.unexpected" ] &&
+    ok "  the directory is moved aside, not deleted" ||
+    bad "  the directory is moved aside, not deleted" "no .unexpected directory"
+teardown
+
+# A FIFO is the case bash's noclobber silently followed: with a reader attached
+# the old hook logged "Security initialized", wrote nothing to disk, and streamed
+# the admin hash and JWT signing key to whoever held the read end.
+setup
+mkfifo "${SK}/security.json"
+( timeout 10 cat "${SK}/security.json" > "${SANDBOX}/leak" 2>/dev/null & )
+check "a FIFO at security.json does not leak the secrets" "$(run_hook)" "0"
+sleep 0.3
+[ ! -s "${SANDBOX}/leak" ] &&
+    ok "  nothing was streamed to the reader" ||
+    bad "  nothing was streamed to the reader" "$(head -c 120 "${SANDBOX}/leak")"
+[ -f "${SK}/security.json" ] && [ ! -p "${SK}/security.json" ] &&
+    ok "  a real security.json replaces it" ||
+    bad "  a real security.json replaces it" "$(ls -ld "${SK}/security.json")"
+grep -q secretKey "${SK}/security.json" 2>/dev/null &&
+    ok "  with the secrets on disk where they belong" ||
+    bad "  with the secrets on disk where they belong" "$(cat "${SK}/security.json" 2>&1)"
+teardown
+
+# Everything above plants its hostile object BEFORE the hook runs, where the type
+# check clears it -- so none of it exercises O_EXCL. This one plants from INSIDE
+# the run, which is the only condition O_EXCL exists for.
+#
+# The hook hashes the admin password between clearing the path and creating it,
+# so a bcrypt shim on PYTHONPATH fires in exactly that window -- deterministic,
+# no sleeps, no spin loop. Reverting the create to O_TRUNC, to open(,'w'), or to
+# touch+chmod+cat must fail this.
+setup
+CANARY="${SANDBOX}/outside-the-data-root"
+printf 'original\n' > "${CANARY}"; chmod 644 "${CANARY}"
+cat > "${SANDBOX}/pylib/bcrypt.py" <<SHIM
+import os
+def gensalt(*a, **k):
+    return b"\$2b\$12\$stubsaltstubsaltstubsa"
+def hashpw(pw, salt):
+    # the racer wins the window: the path was just cleared, so this succeeds
+    os.symlink("${CANARY}", "${SK}/security.json")
+    return b"\$2b\$12\$stubhashstubhashstubhashstubhashstubhas"
+SHIM
+run_hook > /dev/null 2>&1
+[ "$(cat "${CANARY}")" = "original" ] &&
+    ok "a symlink planted after the clear is not written through" ||
+    bad "a symlink planted after the clear is not written through" "$(cat "${CANARY}")"
+check "  and the link target keeps its mode" "$(mode "${CANARY}")" "644"
+teardown
+
+# A plain directory at a guarded path was a race-free boot wedge: the old guard
+# only fired on [ -L ], so cat > failed "Is a directory" on every single boot and
+# five of those put the unit in `failed`. One mkdir from uid 1000 was enough.
+setup
+mkdir -p "${SK}/security.json"
+check "a directory at security.json does not wedge the unit" "$(run_hook)" "0"
+[ -f "${SK}/security.json" ] && [ ! -d "${SK}/security.json" ] &&
+    ok "  a real security.json is created" ||
+    bad "  a real security.json is created" "$(ls -ld "${SK}/security.json")"
+[ -d "${SK}/security.json.unexpected" ] &&
+    ok "  the directory is moved aside, not deleted" ||
+    bad "  the directory is moved aside, not deleted" "no .unexpected directory"
+teardown
+
+# A FIFO is the case bash's noclobber silently followed: with a reader attached
+# the old hook logged "Security initialized", wrote nothing to disk, and streamed
+# the admin hash and JWT signing key to whoever held the read end.
+setup
+mkfifo "${SK}/security.json"
+( timeout 10 cat "${SK}/security.json" > "${SANDBOX}/leak" 2>/dev/null & )
+check "a FIFO at security.json does not leak the secrets" "$(run_hook)" "0"
+sleep 0.3
+[ ! -s "${SANDBOX}/leak" ] &&
+    ok "  nothing was streamed to the reader" ||
+    bad "  nothing was streamed to the reader" "$(head -c 120 "${SANDBOX}/leak")"
+[ -f "${SK}/security.json" ] && [ ! -p "${SK}/security.json" ] &&
+    ok "  a real security.json replaces it" ||
+    bad "  a real security.json replaces it" "$(ls -ld "${SK}/security.json")"
+grep -q secretKey "${SK}/security.json" 2>/dev/null &&
+    ok "  with the secrets on disk where they belong" ||
+    bad "  with the secrets on disk where they belong" "$(cat "${SK}/security.json" 2>&1)"
+teardown
+
+# Everything above plants its hostile object BEFORE the hook runs, where the type
+# check clears it -- so none of it exercises O_EXCL. This one re-plants from
+# inside the run, which is the only condition O_EXCL exists for. Reverting the
+# create to open(,'w') or to touch+chmod+cat must fail here.
+setup
+CANARY="${SANDBOX}/outside-the-data-root"
+printf 'original\n' > "${CANARY}"; chmod 644 "${CANARY}"
+cat > "${SANDBOX}/bin/openssl" <<STUB
 #!/bin/bash
-for arg in "$@"; do
-    case "$arg" in */security.json) echo "rm: cannot remove" >&2; exit 1 ;; esac
-done
-exec /bin/rm "$@"
+# stands in for a uid-1000 process winning the window after the clear
+ln -sfn "${CANARY}" "${SK}/security.json"
+exec /usr/bin/openssl "\$@"
 STUB
-chmod 755 "${SANDBOX}/bin/rm"
-st=$(run_hook)
-[ "$st" != "0" ] &&
-    ok "an unremovable symlink withholds the app rather than writing through" ||
-    bad "an unremovable symlink withholds the app rather than writing through" "exit 0"
-grep -q 'refusing to write through it' "${SANDBOX}/out" &&
-    ok "  and says why" || bad "  and says why" "$(cat "${SANDBOX}/out")"
+chmod 755 "${SANDBOX}/bin/openssl"
+run_hook > /dev/null 2>&1
+[ "$(cat "${CANARY}")" = "original" ] &&
+    ok "a symlink planted after the clear is not written through" ||
+    bad "a symlink planted after the clear is not written through" "$(cat "${CANARY}")"
+check "  and the link target keeps its mode" "$(mode "${CANARY}")" "644"
 teardown
 
 # A full data partition is the realistic trigger: mkdir needs a block, the chmods
@@ -262,7 +355,7 @@ check "  the link target keeps its mode" "$(mode "${CANARY}")" "644"
     ok "  a real security.json replaces the link" ||
     bad "  a real security.json replaces the link" "$(ls -ld "${SK}/security.json")"
 check "  and is 0600" "$(mode "${SK}/security.json")" "600"
-grep -q 'removing unexpected symlink' "${SANDBOX}/out" &&
+grep -q 'unexpected symlink at' "${SANDBOX}/out" &&
     ok "  the removal is logged" || bad "  the removal is logged" "$(cat "${SANDBOX}/out")"
 teardown
 


### PR DESCRIPTION
Closes #211.

## The vulnerability

`security.json`, `plugin-config-data/` and the InfluxDB token config all live in `${SIGNALK_DATA}` — a directory **this hook itself hands to uid 1000** at the end of its own run. So the container can unlink any of them and leave a symlink behind, and every operation that follows dereferences: `chmod`, `touch`, `cat >`, and the one `chown` in the file that lacked `-h`.

Two distinct primitives, and they take different code paths:

**Dangling link → container-to-host-root.** `[ -f ]` is false, so the create branch runs: `touch` creates the attacker's target, `cat >` writes the admin bcrypt hash and the JWT signing key into it, `chown` hands it to uid 1000. Point it at `/etc/ld.so.preload` and uid 1000 then writes a `.so` path that every later root process preloads.

**Link to an existing file → tamper.** `[ -f ]` passes, so the hook takes its "already exists" branch and the `chmod 600` strips the mode off whatever the link points at.

Signal K is Traefik-exposed on the boat LAN and loads a dozen unpinned third-party npm plugins, so a foothold as uid 1000 in that container is the realistic entry point rather than a hypothetical one.

The hook already states this exact rule about itself — *"these live in a directory the container can write, so following a symlink would let it choose which host path root hands over"* — and the `security.json` block was the one place not following it.

## The fix

`drop_symlink` clears a symlink at each path before anything writes there. Parent before child, since clearing a symlinked `plugin-config-data` changes what the paths under it resolve to.

Root never creates a symlink at any of these, so removing one only ever undoes tampering. `node_modules` further down deliberately keeps its narrower rule — a symlink there may be an operator relocating the plugin tree to another disk, so only a *dangling* one is cleared.

Failing to clear one returns non-zero, and under the framework's `set -e` that withholds the app. That is the correct failure direction when the alternative is root writing wherever the container points.

`security.json`'s `chown` also gains `-h`. The guard runs before the writes, but the container owns the directory and can plant a fresh link in the window between the two — `-h` makes that race unwinnable rather than merely unlikely.

## Verification

**45 harness assertions, 33 pytest.** Four scenarios added, all mutation-tested against the pre-fix hook:

| Scenario | Pre-fix behaviour |
|---|---|
| Dangling `security.json` link | **root creates a 292-byte 0600 file at the target, holding the security JSON** |
| Link to an existing file | target's mode stripped 644 → 600 |
| Symlinked InfluxDB token config | admin token written through the link |
| Symlinked `plugin-config-data/` directory | config written inside the link target |

The canary lives outside the sandbox data root, so "was this written through" is a real filesystem observation rather than an assertion about the script's text.

**The dangling case is the one that matters, and it is the one I first missed.** My initial scenarios all used a link to an *existing* file, which exercises only the mode strip — the escalation never fired, and a suite built on that alone would have reported the hook safe. It only surfaced when I ran the new tests against the unpatched hook and saw which assertions stayed green.

## Scope

`${CONTAINER_DATA_ROOT}/admin-password` is deliberately not guarded: its parent is root-owned `755` on-device, so uid 1000 cannot create a name there. If that ever changes it becomes reachable by the same route.

No `VERSION` bump — latest stable is `v0.3.2+24`, `VERSION` is already `0.4.0`, so the cycle is open. `apps/signalk-server/metadata.yaml` `2.30.0-4` → `2.30.0-5` as the per-PR app bump.
