### PR TITLE
Repin Signal K to the -halos.N image tag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -318,9 +318,11 @@ bumping `apps/signalk-server/metadata.yaml`.
 The tag is always exact, and `tests/test_signalk_prestart.py` enforces it.
 Nothing in the curated set is version-pinned (matching upstream), so a rebuild
 resolves a different plugin set -- a floating tag would swap the image underneath
-a verification that had already passed. The tag's `-N` is the image build
-revision; `metadata.yaml`'s `-N` is the package revision. They count
-independently and are not expected to match.
+a verification that had already passed. The tag is
+`v<upstream version>-halos.<build revision>`; `-halos.` is what separates
+upstream's version from ours, and anything reading the tag splits on it. That
+build revision and `metadata.yaml`'s `-N` package revision count independently
+and are not expected to match.
 
 **The baked set only reaches devices whose data volume does not already contain
 those packages.** Signal K resolves `configPath/node_modules` (the data volume)

--- a/apps/signalk-server/docker-compose.yml
+++ b/apps/signalk-server/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     # halos-org/signalk-server-docker. Exact tag, never a floating one: the tag
     # names an artifact that passed that repo's verification, and nothing in the
     # curated set is version-pinned, so a re-resolved rebuild is a different image.
-    image: ghcr.io/halos-org/signalk-server-docker:2.30.0-1
+    image: ghcr.io/halos-org/signalk-server-docker:v2.30.0-halos.2
     container_name: signalk-server
     init: true
     restart: unless-stopped

--- a/apps/signalk-server/metadata.yaml
+++ b/apps/signalk-server/metadata.yaml
@@ -1,6 +1,6 @@
 name: Signal K Server
 app_id: signalk-server
-version: 2.30.0-5
+version: 2.30.0-6
 upstream_version: 2.30.0
 description: Signal K server for marine data processing and routing
 long_description: |

--- a/tests/test_signalk_prestart.py
+++ b/tests/test_signalk_prestart.py
@@ -46,9 +46,13 @@ def test_image_is_the_baked_one_at_an_exact_tag():
     assert repo == "ghcr.io/halos-org/signalk-server-docker", (
         f"not the baked image: {refs[0]}"
     )
-    # <upstream version>-<build revision>, the shape signalk-server-docker
-    # publishes. Rejects latest, a bare version, and any moving alias.
-    assert re.fullmatch(r"\d+\.\d+\.\d+-\d+", tag), f"not an exact tag: {tag!r}"
+    # v<upstream version>-halos.<build revision>, the shape
+    # signalk-server-docker publishes. The `-halos.` separator is what tells
+    # upstream's version from our build revision; anything reading the tag
+    # splits on it. Rejects latest, a bare version, and any moving alias.
+    assert re.fullmatch(r"v\d+\.\d+\.\d+-halos\.\d+", tag), (
+        f"not an exact tag: {tag!r}"
+    )
 
 
 def test_image_exists_in_the_registry():


### PR DESCRIPTION
Closes #218. Last step of halos-org/halos-marine-containers#212.

## What changes

| File | Change |
|---|---|
| `apps/signalk-server/docker-compose.yml` | `2.30.0-1` → `v2.30.0-halos.2` |
| `apps/signalk-server/metadata.yaml` | `2.30.0-5` → `2.30.0-6` |
| `tests/test_signalk_prestart.py` | tag-shape assertion widened to the new convention |
| `AGENTS.md` | tag description updated |

## This one is a rename

Both tags resolve to the same digest:

```
2.30.0-1         sha256:b6e6afd24befea630348153388d53c20c8a3a7d572b05e74c22c6818eb8b13cf
v2.30.0-halos.2  sha256:b6e6afd24befea630348153388d53c20c8a3a7d572b05e74c22c6818eb8b13cf
```

I had written into #218 that this should be treated as a content change, since plugin versions are unpinned and a rebuild can resolve differently. Correct in principle, and measurably not what happened — GHCR carries both tags on one package version. A future `-halos.N` bump will differ.

## The assertion

Widened, not relaxed:

```python
re.fullmatch(r"v\d+\.\d+\.\d+-halos\.\d+", tag)
```

`latest`, a bare version and any moving alias are all still rejected, which is what the check is for.

## The revision advances rather than restarting

`metadata.yaml` goes `2.30.0-5` → `2.30.0-6`. Upstream is unchanged at `2.30.0`, so restarting at `2.30.0-1` would not sort above what is installed. This matches the logic that landed in halos-org/shared-workflows#35, so the bot and a hand repin now agree.

No repo `VERSION` bump: latest stable is `v0.3.2+24` and `VERSION` is already `0.4.0`, so the cycle is open.

## Ordering

The bot fix (shared-workflows#35) landed first, deliberately. The tag pattern is derived from whatever is pinned, so from this PR onward the daily cron tracks the `-halos.N` series — and until #35 it would have written `upstream_version: 2.30.0-halos.N` on the first bump, which is the corruption #212 exists to fix.

## Verification

`tools/test-prestart.sh` passes 87/87 under Linux, and the tag assertions pass here.

Unrelated but found while running it: that harness fails 9 of 87 on macOS, on the `sitecycustomize`-injected racer scenarios, while passing under Linux. `AGENTS.md` documents it as a local command. Filed separately rather than folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FaZt172ZLjpyvzk6JYX9ts