### PR TITLE
Let Signal K assemble the gpsd connection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -313,21 +313,27 @@ Three of the hook's jobs look like leftovers and are not:
 connection's `pipeElements` by hand. That has two consequences that are invisible
 from the file itself, and `settings.json` cannot carry a comment saying so.
 
-**A hand-authored array does not get what `providers/simple` adds.** Signal K
-assembles connections created through the admin UI via `providers/simple`, and
-that assembly is where upstream puts stream fixes. The gpsd branch there is
-`[new Gpsd(subOptions), new Liner(subOptions)]` — a line splitter, added in
-v2.25.0 because gpsd coalesces a whole NMEA reporting cycle into one TCP write
-and the parser cannot read several sentences as one blob. Our array bypassed that
-branch and so lacked the splitter, which meant the connection produced no
-position at any pinned version; upgrading the server could never have fixed it.
-`tests/test_signalk_settings.py` guards the splitter and its position in the
-pipeline. Anything else `simple` acquires upstream has to be mirrored here by
-hand, and nothing will tell us when that happens.
+**Let `providers/simple` assemble the pipeline; do not spell out `pipeElements`.**
+Signal K builds a gpsd connection as `Gpsd → Liner → nmea0183-signalk`, and that
+assembly is where upstream puts stream fixes. The Liner is load-bearing: gpsd
+writes a whole NMEA reporting cycle in one TCP write, and without a splitter the
+parser gets several sentences as one blob and rejects all of them. It was added
+upstream in v2.25.0.
 
-The same choice costs operator control: `editable: true` is set only for a
-`providers/simple` element, so a hand-authored connection renders in the admin UI
-as a read-only textarea whose only action is Delete.
+This config used to spell the elements out, which bypassed that branch entirely —
+so the connection produced no position at any pinned version, and no server
+upgrade could have supplied the fix. Anything else `simple` gains upstream would
+have had to be mirrored here by hand, with nothing to signal when that happened.
+
+Spelling it out also costs operator control: the server sets `editable: true`
+only for a single `providers/simple` element, so a hand-authored connection
+renders in the admin UI as a read-only textarea whose one action is Delete.
+
+Two details worth keeping: bake `host`, not `hostname` — the admin UI writes
+`host` and the server reads `hostname ?? host`, so a baked `hostname` silently
+overrides any later UI edit. And `tests/test_signalk_settings.py` asserts the
+connection is a single `providers/simple` element, precisely so a future edit
+cannot quietly go back to spelling the pipeline out.
 
 **`default-data/` seeds copy-if-absent.** The generated postinst copies each file
 only `if [ ! -f "$dst_file" ]`, and this app's `prestart.sh` deliberately never

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -307,6 +307,37 @@ Three of the hook's jobs look like leftovers and are not:
   device. Left root-owned, every app-store plugin install fails EACCES forever --
   and app-store updates are the only thing keeping a baked plugin updatable.
 
+### The baked Signal K connections
+
+`apps/signalk-server/default-data/data/settings.json` spells out the gpsd
+connection's `pipeElements` by hand. That has two consequences that are invisible
+from the file itself, and `settings.json` cannot carry a comment saying so.
+
+**A hand-authored array does not get what `providers/simple` adds.** Signal K
+assembles connections created through the admin UI via `providers/simple`, and
+that assembly is where upstream puts stream fixes. The gpsd branch there is
+`[new Gpsd(subOptions), new Liner(subOptions)]` — a line splitter, added in
+v2.25.0 because gpsd coalesces a whole NMEA reporting cycle into one TCP write
+and the parser cannot read several sentences as one blob. Our array bypassed that
+branch and so lacked the splitter, which meant the connection produced no
+position at any pinned version; upgrading the server could never have fixed it.
+`tests/test_signalk_settings.py` guards the splitter and its position in the
+pipeline. Anything else `simple` acquires upstream has to be mirrored here by
+hand, and nothing will tell us when that happens.
+
+The same choice costs operator control: `editable: true` is set only for a
+`providers/simple` element, so a hand-authored connection renders in the admin UI
+as a read-only textarea whose only action is Delete.
+
+**`default-data/` seeds copy-if-absent.** The generated postinst copies each file
+only `if [ ! -f "$dst_file" ]`, and this app's `prestart.sh` deliberately never
+writes `settings.json` (see the symlink-hardening notes above — adding a write
+there is what would expose it). So a change to this file reaches devices with no
+`settings.json` yet, and nothing else. Fielded devices keep whatever they were
+first seeded with, while `apt` reports success and the app version bumps. This is
+the same reach constraint as the baked plugin set below, and a fix here needs the
+same explicit decision: migrate, or accept and say so.
+
 ### Signal K Plugin Set
 
 The curated plugins are baked into the image, not installed at runtime. They live

--- a/apps/signalk-server/default-data/data/settings.json
+++ b/apps/signalk-server/default-data/data/settings.json
@@ -6,18 +6,17 @@
       "id": "gpsd",
       "pipeElements": [
         {
-          "type": "providers/gpsd",
+          "type": "providers/simple",
           "options": {
-            "hostname": "localhost",
-            "port": 2947,
-            "noDataReceivedTimeout": 30
+            "type": "NMEA0183",
+            "logging": false,
+            "subOptions": {
+              "type": "gpsd",
+              "host": "localhost",
+              "port": 2947,
+              "noDataReceivedTimeout": 30
+            }
           }
-        },
-        {
-          "type": "providers/liner"
-        },
-        {
-          "type": "providers/nmea0183-signalk"
         }
       ],
       "enabled": true

--- a/apps/signalk-server/default-data/data/settings.json
+++ b/apps/signalk-server/default-data/data/settings.json
@@ -15,6 +15,9 @@
           }
         },
         {
+          "type": "providers/liner"
+        },
+        {
           "type": "providers/nmea0183-signalk"
         }
       ],

--- a/apps/signalk-server/default-data/data/settings.json
+++ b/apps/signalk-server/default-data/data/settings.json
@@ -10,8 +10,7 @@
           "options": {
             "hostname": "localhost",
             "port": 2947,
-            "noDataReceivedTimeout": 30,
-            "reconnectInterval": 15
+            "noDataReceivedTimeout": 30
           }
         },
         {

--- a/apps/signalk-server/metadata.yaml
+++ b/apps/signalk-server/metadata.yaml
@@ -1,6 +1,6 @@
 name: Signal K Server
 app_id: signalk-server
-version: 2.30.0-6
+version: 2.30.0-7
 upstream_version: 2.30.0
 description: Signal K server for marine data processing and routing
 long_description: |

--- a/tests/test_signalk_settings.py
+++ b/tests/test_signalk_settings.py
@@ -1,4 +1,12 @@
-"""Tests for the Signal K settings seeded into a new data volume."""
+"""Tests for the Signal K settings seeded into a new data volume.
+
+These assertions cover the *hand-authored* form of the gpsd connection, where
+this repo spells out `pipeElements` itself. Signal K also accepts the connection
+as a single `providers/simple` element, which assembles the same pipeline
+internally and would make the line splitter automatic; if the baked config ever
+moves to that form, these checks stop applying and should move with it rather
+than be forced to pass.
+"""
 
 import json
 from pathlib import Path
@@ -14,6 +22,11 @@ SETTINGS = (
     / "settings.json"
 )
 
+# The gpsd daemon's own default, and what the host service listens on. Signal K
+# runs with network_mode: host, so localhost here is the host's gpsd.
+GPSD_HOST = "localhost"
+GPSD_PORT = 2947
+
 
 @pytest.fixture
 def settings():
@@ -21,24 +34,35 @@ def settings():
         return json.load(f)
 
 
-def gpsd_pipe_elements(settings):
-    """The pipeElements of the baked gpsd connection."""
+def gpsd_provider(settings):
     providers = [p for p in settings["pipedProviders"] if p["id"] == "gpsd"]
     assert len(providers) == 1, "expected exactly one gpsd provider"
-    return [e["type"] for e in providers[0]["pipeElements"]]
+    return providers[0]
+
+
+def hand_authored_elements(provider):
+    """Element types, or a skip when the connection is not hand-authored."""
+    types = [e["type"] for e in provider["pipeElements"]]
+    if "providers/simple" in types:
+        pytest.skip("connection is built by providers/simple, which adds its own liner")
+    return types
 
 
 def test_gpsd_pipeline_splits_lines_before_parsing(settings):
     """gpsd writes a whole NMEA reporting cycle in one TCP write.
 
-    Without a liner between the source and the parser, nmea0183-signalk sees
+    Without a splitter between the source and the parser, nmea0183-signalk sees
     several sentences as one unparseable blob and position never arrives -- only
-    a sentence that happens to land alone in a write gets through. Upstream adds
-    the Liner for gpsd connections built through the admin UI (providers/simple),
-    which this hand-authored pipeElements array bypasses entirely, so upgrading
-    signalk-server cannot fix it.
+    a sentence that happens to land alone in a write gets through. Verified
+    against the pinned server: one CRLF-terminated ZDA+GGA+RMC burst delivered
+    as a single write produces one delta without the liner and three, including
+    navigation.position, with it.
+
+    Upstream inserts the Liner for gpsd connections built through
+    providers/simple, and has since v2.25.0. A hand-authored pipeElements array
+    bypasses that branch, so no amount of upgrading signalk-server can supply it.
     """
-    elements = gpsd_pipe_elements(settings)
+    elements = hand_authored_elements(gpsd_provider(settings))
 
     assert "providers/liner" in elements, (
         "gpsd connection has no line splitter; multi-sentence writes will not parse"
@@ -49,6 +73,20 @@ def test_gpsd_pipeline_splits_lines_before_parsing(settings):
     ), "the liner must sit between the gpsd source and the NMEA parser"
 
 
+def test_gpsd_connection_points_at_the_host_daemon(settings):
+    """A wrong endpoint costs the position as completely as a missing splitter."""
+    elements = gpsd_provider(settings)["pipeElements"]
+    source = next(e for e in elements if e["type"] == "providers/gpsd")
+    options = source.get("options", {})
+
+    assert options.get("hostname", options.get("host")) == GPSD_HOST
+    assert options.get("port") == GPSD_PORT
+
+
 def test_gpsd_connection_is_enabled(settings):
-    providers = [p for p in settings["pipedProviders"] if p["id"] == "gpsd"]
-    assert providers[0]["enabled"] is True
+    """Signal K treats a missing `enabled` key as enabled, so only False is wrong."""
+    provider = gpsd_provider(settings)
+
+    assert provider.get("enabled", True) is not False, (
+        "the gpsd connection is disabled, so no position will be produced"
+    )

--- a/tests/test_signalk_settings.py
+++ b/tests/test_signalk_settings.py
@@ -1,12 +1,4 @@
-"""Tests for the Signal K settings seeded into a new data volume.
-
-These assertions cover the *hand-authored* form of the gpsd connection, where
-this repo spells out `pipeElements` itself. Signal K also accepts the connection
-as a single `providers/simple` element, which assembles the same pipeline
-internally and would make the line splitter automatic; if the baked config ever
-moves to that form, these checks stop applying and should move with it rather
-than be forced to pass.
-"""
+"""Tests for the Signal K settings seeded into a new data volume."""
 
 import json
 from pathlib import Path
@@ -22,8 +14,8 @@ SETTINGS = (
     / "settings.json"
 )
 
-# The gpsd daemon's own default, and what the host service listens on. Signal K
-# runs with network_mode: host, so localhost here is the host's gpsd.
+# gpsd's own default port, and what the host service listens on. Signal K runs
+# with network_mode: host, so localhost here is the host's gpsd.
 GPSD_HOST = "localhost"
 GPSD_PORT = 2947
 
@@ -40,47 +32,47 @@ def gpsd_provider(settings):
     return providers[0]
 
 
-def hand_authored_elements(provider):
-    """Element types, or a skip when the connection is not hand-authored."""
-    types = [e["type"] for e in provider["pipeElements"]]
-    if "providers/simple" in types:
-        pytest.skip("connection is built by providers/simple, which adds its own liner")
-    return types
+def test_gpsd_connection_is_assembled_by_the_server(settings):
+    """The pipeline must be built by providers/simple, not spelled out here.
 
+    Signal K assembles a gpsd connection as Gpsd -> Liner -> nmea0183-signalk.
+    The Liner matters: gpsd writes a whole NMEA reporting cycle in one TCP
+    write, and without a splitter the parser receives several sentences as one
+    blob and rejects all of them. Verified against the pinned image with a gpsd
+    that writes ZDA+GGA+RMC in a single write: spelled out by hand without a
+    liner, the parser logs one error whose content is all three sentences
+    concatenated; through providers/simple, all three parse.
 
-def test_gpsd_pipeline_splits_lines_before_parsing(settings):
-    """gpsd writes a whole NMEA reporting cycle in one TCP write.
-
-    Without a splitter between the source and the parser, nmea0183-signalk sees
-    several sentences as one unparseable blob and position never arrives -- only
-    a sentence that happens to land alone in a write gets through. Verified
-    against the pinned server: one CRLF-terminated ZDA+GGA+RMC burst delivered
-    as a single write produces one delta without the liner and three, including
-    navigation.position, with it.
-
-    Upstream inserts the Liner for gpsd connections built through
-    providers/simple, and has since v2.25.0. A hand-authored pipeElements array
-    bypasses that branch, so no amount of upgrading signalk-server can supply it.
+    Spelling the elements out here means the pipeline stops tracking upstream --
+    that is exactly how the Liner came to be missing, and no server upgrade
+    could supply it. It also costs operator control: the server marks a
+    connection editable only when it is a single providers/simple element, so a
+    hand-authored one appears in the admin UI as a read-only box whose only
+    action is Delete.
     """
-    elements = hand_authored_elements(gpsd_provider(settings))
+    elements = gpsd_provider(settings)["pipeElements"]
 
-    assert "providers/liner" in elements, (
-        "gpsd connection has no line splitter; multi-sentence writes will not parse"
+    assert len(elements) == 1, (
+        "the gpsd connection must be one providers/simple element; spelling out "
+        "the pipeline stops it tracking upstream and makes it uneditable"
     )
-    assert elements.index("providers/gpsd") < elements.index("providers/liner")
-    assert elements.index("providers/liner") < elements.index(
-        "providers/nmea0183-signalk"
-    ), "the liner must sit between the gpsd source and the NMEA parser"
+    assert elements[0]["type"] == "providers/simple"
+
+    options = elements[0]["options"]
+    assert options["type"] == "NMEA0183"
+    assert options["subOptions"]["type"] == "gpsd"
 
 
 def test_gpsd_connection_points_at_the_host_daemon(settings):
     """A wrong endpoint costs the position as completely as a missing splitter."""
-    elements = gpsd_provider(settings)["pipeElements"]
-    source = next(e for e in elements if e["type"] == "providers/gpsd")
-    options = source.get("options", {})
+    sub = gpsd_provider(settings)["pipeElements"][0]["options"]["subOptions"]
 
-    assert options.get("hostname", options.get("host")) == GPSD_HOST
-    assert options.get("port") == GPSD_PORT
+    # `host`, not `hostname`: the admin UI writes `host`, and the server reads
+    # `hostname ?? host`, so a baked `hostname` would silently override any
+    # later edit made through the UI.
+    assert "hostname" not in sub, "bake `host`; `hostname` shadows UI edits"
+    assert sub["host"] == GPSD_HOST
+    assert sub["port"] == GPSD_PORT
 
 
 def test_gpsd_connection_is_enabled(settings):

--- a/tests/test_signalk_settings.py
+++ b/tests/test_signalk_settings.py
@@ -1,0 +1,54 @@
+"""Tests for the Signal K settings seeded into a new data volume."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+SETTINGS = (
+    Path(__file__).parent.parent
+    / "apps"
+    / "signalk-server"
+    / "default-data"
+    / "data"
+    / "settings.json"
+)
+
+
+@pytest.fixture
+def settings():
+    with open(SETTINGS) as f:
+        return json.load(f)
+
+
+def gpsd_pipe_elements(settings):
+    """The pipeElements of the baked gpsd connection."""
+    providers = [p for p in settings["pipedProviders"] if p["id"] == "gpsd"]
+    assert len(providers) == 1, "expected exactly one gpsd provider"
+    return [e["type"] for e in providers[0]["pipeElements"]]
+
+
+def test_gpsd_pipeline_splits_lines_before_parsing(settings):
+    """gpsd writes a whole NMEA reporting cycle in one TCP write.
+
+    Without a liner between the source and the parser, nmea0183-signalk sees
+    several sentences as one unparseable blob and position never arrives -- only
+    a sentence that happens to land alone in a write gets through. Upstream adds
+    the Liner for gpsd connections built through the admin UI (providers/simple),
+    which this hand-authored pipeElements array bypasses entirely, so upgrading
+    signalk-server cannot fix it.
+    """
+    elements = gpsd_pipe_elements(settings)
+
+    assert "providers/liner" in elements, (
+        "gpsd connection has no line splitter; multi-sentence writes will not parse"
+    )
+    assert elements.index("providers/gpsd") < elements.index("providers/liner")
+    assert elements.index("providers/liner") < elements.index(
+        "providers/nmea0183-signalk"
+    ), "the liner must sit between the gpsd source and the NMEA parser"
+
+
+def test_gpsd_connection_is_enabled(settings):
+    providers = [p for p in settings["pipedProviders"] if p["id"] == "gpsd"]
+    assert providers[0]["enabled"] is True


### PR DESCRIPTION
## The bug

The baked Signal K gpsd connection never produced a position.

gpsd doesn't send one NMEA sentence per TCP write — it sends a whole reporting cycle (ZDA, GGA, RMC, GSA, GSV…) in a single write. Signal K's NMEA parser expects one sentence at a time, so it saw the whole burst as one malformed sentence and threw all of it away. Occasionally a sentence landed alone in a write and got through, which is why the symptom was a stray timestamp and never a position.

Reported by Aswin Bouwmeester after fitting a MAX-M8Q GNSS HAT to a HALPI2.

## The cause

Signal K needs a "liner" between the two — a step that splits the burst into individual sentences. It has one, and it inserts it automatically: when you create a gpsd connection in the admin UI, the server builds the pipeline for you as

```
Gpsd → Liner → nmea0183-signalk
```

We weren't using that. Our `settings.json` listed the pipeline stages by hand, and the hand-written list had no liner. So the fix existed in every version we shipped and could never reach us — upgrading Signal K would not have helped, because the fix lives in the assembly step our config skipped.

## The change

Stop listing the stages. Hand the server the same single element the admin UI writes, and let it build the pipeline:

```json
{
  "type": "providers/simple",
  "options": {
    "type": "NMEA0183",
    "subOptions": { "type": "gpsd", "host": "localhost", "port": 2947 }
  }
}
```

Same three stages, but now the server owns them. The liner arrives because the server puts it there, and any future change upstream makes to gpsd handling arrives the same way instead of silently passing us by.

Two side effects, both good:

- **The connection becomes editable.** Signal K only offers a connection's settings form when it's a single `providers/simple` element. The old hand-written form showed up in the admin UI as a read-only box whose only button was Delete — no host, no port, no enable/disable.
- **One dead option removed.** `reconnectInterval: 15` was in the old config and is read by nothing; the reconnect backoff is hardcoded to 5 s.

One detail worth keeping: the config says `host`, not `hostname`. The admin UI writes `host`, and the server prefers `hostname` when both are present — so a baked `hostname` would silently override whatever a user later set in the UI. There's a test asserting it stays absent.

## How it was verified

Ran the pinned image (`v2.30.0-halos.2`) against a fake gpsd that writes ZDA+GGA+RMC in one TCP write, exactly as the real one does:

| Config | Result |
|---|---|
| stages listed by hand, no liner | one parse error containing all three sentences concatenated — nothing parses |
| `providers/simple` (this PR) | the only parse error is gpsd's JSON version banner, which isn't NMEA; all three sentences parse |

`tests/test_signalk_settings.py` asserts the connection stays a single `providers/simple` element, so a future edit can't quietly go back to listing stages. It fails on all eight mutations tried, including reverting to the hand-written form (with *and* without a liner), swapping `host` for `hostname`, and changing the port.

## What this does not fix

Existing devices. `default-data/` is only copied when the file is absent, so a device that already has a `settings.json` keeps it — the fix reaches new installs only. Tracked in #223, which also covers whether `prestart.sh` should migrate existing files (it deliberately never writes `settings.json` today, for security reasons documented in AGENTS.md).

Closes #217
