### PR TITLE
Repair the gpsd connection on already-shipped devices

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -227,10 +227,13 @@ pulls and boots the InfluxDB image.
 ### Signal K Prestart Hook
 
 `apps/signalk-server/prestart.sh` has a bash harness that stubs chown, so it
-needs no Docker, no network and no root. bcrypt is not stubbed -- the python
-block that imports it is the thing under test -- so `python3-bcrypt` has to be
-installed to run this. Unlike the InfluxDB harness it runs in CI, via
-`tests/test_signalk_prestart.py`:
+needs no Docker and no network. It must **not** run as root, and refuses to:
+several scenarios stage an unwritable path with `chmod 555`, which root ignores,
+so a root run reports failures that are about the caller rather than the hook —
+and one scenario passes without exercising the failure it names. bcrypt is not
+stubbed -- the python block that imports it is the thing under test -- so
+`python3-bcrypt` has to be installed to run this. Unlike the InfluxDB harness it
+runs in CI, via `tests/test_signalk_prestart.py`:
 
 ```bash
 ./tools/test-prestart.sh
@@ -295,10 +298,11 @@ Three of the hook's jobs look like leftovers and are not:
   would give away the one credential meant to outlive a compromise.
 
   Paths that are safe today for a *different* reason, and would silently become
-  the same bug if that changed: `oidc-secret` and `$RUNTIME_ENV` are safe only
-  because their parent is root-owned and outside the bind mount; `package.json`
-  only because it is `chown -h`'d and never written. Mount
-  `${CONTAINER_DATA_ROOT}` into a container and they are exposed.
+  the same bug if that changed, each with the action that would expose it:
+  `oidc-secret` and `$RUNTIME_ENV` are safe only because their parent is
+  root-owned and outside the bind mount, so mounting `${CONTAINER_DATA_ROOT}`
+  into a container exposes them; `package.json` only because nothing writes it,
+  so adding a write does.
 
   `settings.json` was in that list until the gpsd liner migration below gave it a
   writer, and it is the case to read before adding another one. The file holds
@@ -352,7 +356,7 @@ needs the same explicit decision: migrate, or accept and say so.
 **The missing liner is migrated; nothing else is.** `prestart.sh` splices a
 `providers/liner` into a connection whose `pipeElements` are `providers/gpsd`
 immediately followed by `providers/nmea0183-signalk`, keeping the file as it was
-at `settings.json.pre-liner`. Three things decide the shape of that, and a wider
+at `settings.json.pre-liner`. Four things decide the shape of that, and a wider
 migration gets each of them wrong:
 
 - **The adjacency is also the unmodified check.** The server marks only a single
@@ -367,12 +371,26 @@ migration gets each of them wrong:
 - **Failure warns; it never refuses to start.** A device left on the old
   connection shows no position, which is where it already was. A device whose
   `ExecStartPre` aborts has no navigation server at all.
+- **The record of the repair is written after the repair, never before.** The
+  backup doubles as that record, and writing it first is what makes a partial
+  write or an interrupted boot fatal: the next boot reads a half-written file as
+  a completed migration and never looks at the connection again. In this order a
+  failure anywhere before the rename leaves `settings.json` untouched and nothing
+  claiming the migration ran, so the next boot retries; a failure after it costs
+  the undo copy and not the repair. Idempotency does not depend on the record —
+  the migrated file no longer matches the predicate.
 
-It runs from `ExecStartPre` with the container stopped, which is the only point
-where Signal K — the file's other writer — provably is not mid-write. That is why
-it lives here rather than in the postinst, which runs while the container may
-still be up, and which the generator owns end to end: there is no app-level hook
-in it.
+It lives in `ExecStartPre` rather than in the postinst because the unit stops the
+container before restarting it, so Signal K — the file's other writer — is
+normally not running while this rewrites the file. The postinst runs while the
+container may still be up, and the generator owns it end to end: there is no
+app-level hook in it. "Normally" is the honest word: `restart: unless-stopped` in
+the compose file plus a bare `After=docker.service` on the unit means an unclean
+shutdown leaves the container in dockerd's restore set, and it can be up again
+before the hook runs. `docker compose up` then attaches instead of recreating, so
+the server keeps the settings it read at its own start and the repair reaches
+disk without reaching the running server. It takes effect at the next start that
+actually recreates the container.
 
 **It has an expiry.** The population it repairs is closed, so the hook carries a
 `REMOVE AFTER 2027-08-01` marker naming everything that goes with it. Past that

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -296,10 +296,17 @@ Three of the hook's jobs look like leftovers and are not:
 
   Paths that are safe today for a *different* reason, and would silently become
   the same bug if that changed: `oidc-secret` and `$RUNTIME_ENV` are safe only
-  because their parent is root-owned and outside the bind mount; `settings.json`
-  and `package.json` only because they are `chown -h`'d and never written. Mount
-  `${CONTAINER_DATA_ROOT}` into a container, or add a `cat >` to `settings.json`,
-  and they are exposed.
+  because their parent is root-owned and outside the bind mount; `package.json`
+  only because it is `chown -h`'d and never written. Mount
+  `${CONTAINER_DATA_ROOT}` into a container and they are exposed.
+
+  `settings.json` was in that list until the gpsd liner migration below gave it a
+  writer, and it is the case to read before adding another one. The file holds
+  nothing secret, so what makes it dangerous is only that root writes into a
+  directory uid 1000 owns — the same property, arrived at without a secret to
+  point to. It goes through the same descriptor-relative `O_EXCL` create and
+  `renameat` as everything else here, and the temp and backup names it writes are
+  covered by those creates rather than by a guard that lists them.
 
 - **`node_modules` and `package.json` are handed to uid 1000 on every start.**
   `signalk-halpi`'s postinst creates both as root when it registers itself as a
@@ -309,9 +316,9 @@ Three of the hook's jobs look like leftovers and are not:
 
 ### The baked Signal K connections
 
-`apps/signalk-server/default-data/data/settings.json` spells out the gpsd
-connection's `pipeElements` by hand. That has two consequences that are invisible
-from the file itself, and `settings.json` cannot carry a comment saying so.
+`apps/signalk-server/default-data/data/settings.json` used to spell out the gpsd
+connection's `pipeElements` by hand. The rules that replaced it are invisible from
+the file itself, and `settings.json` cannot carry a comment saying so.
 
 **Let `providers/simple` assemble the pipeline; do not spell out `pipeElements`.**
 Signal K builds a gpsd connection as `Gpsd → Liner → nmea0183-signalk`, and that
@@ -336,13 +343,42 @@ connection is a single `providers/simple` element, precisely so a future edit
 cannot quietly go back to spelling the pipeline out.
 
 **`default-data/` seeds copy-if-absent.** The generated postinst copies each file
-only `if [ ! -f "$dst_file" ]`, and this app's `prestart.sh` deliberately never
-writes `settings.json` (see the symlink-hardening notes above — adding a write
-there is what would expose it). So a change to this file reaches devices with no
+only `if [ ! -f "$dst_file" ]`, so a change to this file reaches devices with no
 `settings.json` yet, and nothing else. Fielded devices keep whatever they were
 first seeded with, while `apt` reports success and the app version bumps. This is
-the same reach constraint as the baked plugin set below, and a fix here needs the
-same explicit decision: migrate, or accept and say so.
+the same reach constraint as the baked plugin set below, and every change here
+needs the same explicit decision: migrate, or accept and say so.
+
+**The missing liner is migrated; nothing else is.** `prestart.sh` splices a
+`providers/liner` into a connection whose `pipeElements` are `providers/gpsd`
+immediately followed by `providers/nmea0183-signalk`, keeping the file as it was
+at `settings.json.pre-liner`. Three things decide the shape of that, and a wider
+migration gets each of them wrong:
+
+- **The adjacency is also the unmodified check.** The server marks only a single
+  `providers/simple` element editable, so the hand-authored connection was
+  read-only in the admin UI — no device reached this shape by being configured.
+  A connection recreated through the UI is one `providers/simple` element, and a
+  hand-repaired one already has three. Neither matches, and both are left alone.
+- **Repairing the defect is not the same as adopting the current shape.**
+  Rewriting the connection to `providers/simple` would discard a hand-edited host
+  or port and change its identity in the admin UI. The liner is what we shipped
+  wrong; the rest is only what we would write today.
+- **Failure warns; it never refuses to start.** A device left on the old
+  connection shows no position, which is where it already was. A device whose
+  `ExecStartPre` aborts has no navigation server at all.
+
+It runs from `ExecStartPre` with the container stopped, which is the only point
+where Signal K — the file's other writer — provably is not mid-write. That is why
+it lives here rather than in the postinst, which runs while the container may
+still be up, and which the generator owns end to end: there is no app-level hook
+in it.
+
+**It has an expiry.** The population it repairs is closed, so the hook carries a
+`REMOVE AFTER 2027-08-01` marker naming everything that goes with it. Past that
+date the migration is a root write into a container-owned directory that can no
+longer find anything to repair — open an issue to take it out rather than
+renewing it by default.
 
 ### Signal K Plugin Set
 

--- a/apps/signalk-server/metadata.yaml
+++ b/apps/signalk-server/metadata.yaml
@@ -1,6 +1,6 @@
 name: Signal K Server
 app_id: signalk-server
-version: 2.30.0-7
+version: 2.30.0-8
 upstream_version: 2.30.0
 description: Signal K server for marine data processing and routing
 long_description: |

--- a/apps/signalk-server/prestart.sh
+++ b/apps/signalk-server/prestart.sh
@@ -151,21 +151,25 @@ def clear_unexpected(dfd, name, want_dir=False):
     return True
 
 
-def create_exclusive(dfd, name, content):
+def create_exclusive(dfd, name, content, mode=0o600):
     """Create and fill `name`, refusing to follow anything.
 
     O_EXCL|O_NOFOLLOW is a real kernel exclusive create. Bash's `noclobber` is
     not equivalent: it stats first and only adds O_EXCL when that stat fails, so
     a symlink to a FIFO or a device is followed.
+
+    The default is the secret-file mode. It is a parameter because settings.json
+    holds no secret and is read and written by the container: tightening it to
+    0600 as a side effect of repairing it would be a second, silent change.
     """
     fd = os.open(
         name,
         os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
-        0o600,
+        mode,
         dir_fd=dfd,
     )
     try:
-        os.fchmod(fd, 0o600)  # explicit: the mode above is masked by umask
+        os.fchmod(fd, mode)  # explicit: the mode above is masked by umask
     except BaseException:
         os.close(fd)
         raise
@@ -173,7 +177,7 @@ def create_exclusive(dfd, name, content):
         f.write(content)
 
 
-def create_guarded(dfd, name, content, replace=False):
+def create_guarded(dfd, name, content, replace=False, mode=0o600):
     """Clear the name and create it, conceding only after losing repeatedly.
 
     O_EXCL turns a lost race into EEXIST instead of a write through whatever was
@@ -196,7 +200,7 @@ def create_guarded(dfd, name, content, replace=False):
                 warn("could not replace %s: %s" % (name, exc))
                 return False
         try:
-            create_exclusive(dfd, name, content)
+            create_exclusive(dfd, name, content, mode)
             return True
         except FileExistsError:
             warn("%s reappeared between the clear and the create; retrying" % name)
@@ -281,6 +285,117 @@ def configure_influx(sk_fd, token):
         os.close(cfg_fd)
 
 
+# REMOVE AFTER 2027-08-01. This repairs one closed population -- devices seeded
+# between v0.3.1+13 and the providers/simple fix -- and every boot after the last
+# of them has been repaired, reimaged or retired is a root write into a
+# container-owned directory bought for nothing. Removing it means deleting
+# migrate_gpsd_liner and its call site, the "the gpsd liner migration" scenarios
+# in tools/test-prestart.sh, and the settings.json paragraphs in AGENTS.md, after
+# which settings.json goes back to being a path this hook never writes.
+def migrate_gpsd_liner(sk_fd):
+    """Splice the missing Liner into a gpsd connection seeded before the fix.
+
+    gpsd writes a whole NMEA reporting cycle in one TCP write, so a pipeline that
+    hands it straight to the parser delivers several sentences as one blob and
+    every burst is rejected -- no position, at any server version. `default-data`
+    is copy-if-absent, so correcting the baked file reached new installs only:
+    every device seeded from v0.3.1+13 onward keeps the broken pipeline, while
+    apt reports success and the app version bumps.
+
+    The adjacency is the whole predicate, and it doubles as the unmodified check.
+    The server marks only a single `providers/simple` element editable, so the
+    hand-authored connection renders in the admin UI as a read-only textarea
+    whose one action is Delete -- no device reached this shape by being
+    configured. A connection recreated through the UI is one `providers/simple`
+    element; a hand-repaired one already has three. Neither matches.
+
+    Only the Liner goes in. Rewriting the connection to `providers/simple`, which
+    is what a new install now seeds, would discard a hand-edited host or port and
+    change the connection's identity in the admin UI -- more than repairing the
+    defect we shipped.
+
+    This is the only writer of settings.json here, and the reason that path needs
+    the same discipline as the secret files above: what makes it dangerous is
+    root writing into a directory uid 1000 owns, not the contents. It runs from
+    ExecStartPre with the container stopped, which is the only point where Signal
+    K -- the file's other writer -- provably is not mid-write.
+    """
+    backup = "settings.json.pre-liner"
+    try:
+        fd = open_regular(sk_fd, "settings.json")
+    except FileNotFoundError:
+        return  # a fresh install has none until the postinst seeds default-data
+
+    # The backup doubles as the record that this already ran, which is what keeps
+    # a repair from becoming a standing policy: an operator who restores the old
+    # connection deliberately would otherwise have it spliced again on the next
+    # boot, with no way to refuse short of uninstalling the package.
+    try:
+        os.lstat(backup, dir_fd=sk_fd)
+        os.close(fd)
+        return
+    except FileNotFoundError:
+        pass
+
+    with os.fdopen(fd) as f:  # owns fd from here, including on failure
+        mode = stat.S_IMODE(os.fstat(f.fileno()).st_mode)
+        original = f.read()
+
+    settings = json.loads(original)
+    if not isinstance(settings, dict):
+        raise ValueError(
+            "settings.json is a %s, not an object" % type(settings).__name__
+        )
+
+    spliced = False
+    for provider in settings.get("pipedProviders") or []:
+        elements = provider.get("pipeElements") if isinstance(provider, dict) else None
+        if not isinstance(elements, list):
+            continue
+        for i in range(len(elements) - 1):
+            pair = elements[i:i + 2]
+            if all(isinstance(e, dict) for e in pair) and [
+                e.get("type") for e in pair
+            ] == ["providers/gpsd", "providers/nmea0183-signalk"]:
+                elements.insert(i + 1, {"type": "providers/liner"})
+                spliced = True
+                break
+
+    if not spliced:
+        return
+
+    # The original goes down first: it is what the splice is derived from, and a
+    # migration whose backup failed is one the operator cannot undo.
+    if not create_guarded(sk_fd, backup, original, mode=mode):
+        warn("cannot write %s; leaving the gpsd connection alone" % backup)
+        return
+
+    tmp = "settings.json.tmp"
+    body = json.dumps(settings, indent=2) + "\n"
+    migrated = False
+    try:
+        if create_guarded(sk_fd, tmp, body, replace=True, mode=mode):
+            # renameat replaces the name and never follows it, so a symlink
+            # swapped in after the read above is overwritten rather than written
+            # through.
+            os.replace(tmp, "settings.json", src_dir_fd=sk_fd, dst_dir_fd=sk_fd)
+            migrated = True
+        else:
+            warn("cannot write %s; leaving the gpsd connection alone" % tmp)
+    finally:
+        if not migrated:
+            # A backup with no migration behind it reads as one on the next boot
+            # and would retire the repair without ever having made it.
+            try:
+                os.unlink(backup, dir_fd=sk_fd)
+            except OSError as exc:
+                warn("could not remove %s after a failed migration: %s" % (backup, exc))
+
+    if migrated:
+        print("Added the missing providers/liner to the gpsd connection")
+        print("The connection as it was is kept at %s/%s" % (SK_DATA, backup))
+
+
 sk_fd = open_dir(SK_DATA)
 root_fd = open_dir(DATA_ROOT)
 
@@ -325,6 +440,14 @@ if not existing:
     print("Security initialized with admin user.")
     print("NOTE: Local admin password stored in %s/admin-password" % DATA_ROOT)
     print("This is a fallback for emergency access. Use OIDC for regular login.")
+
+# A repair, not a precondition: a device left on the old connection shows no
+# position, which is where it already was, while an exception on the way there is
+# an ExecStartPre abort and no navigation server at all.
+try:
+    migrate_gpsd_liner(sk_fd)
+except Exception as exc:
+    warn("gpsd connection not migrated: %s" % exc)
 
 # Logging is not navigation: a failure here must not cost the boot.
 if INFLUX_TOKEN:

--- a/apps/signalk-server/prestart.sh
+++ b/apps/signalk-server/prestart.sh
@@ -173,7 +173,9 @@ def create_exclusive(dfd, name, content, mode=0o600):
     except BaseException:
         os.close(fd)
         raise
-    with os.fdopen(fd, "w") as f:  # owns fd from here, including on failure
+    # UTF-8 explicitly: every caller writes JSON, and text mode would otherwise
+    # encode it in the process locale.
+    with os.fdopen(fd, "w", encoding="utf-8") as f:  # owns fd, including on failure
         f.write(content)
 
 
@@ -184,9 +186,11 @@ def create_guarded(dfd, name, content, replace=False, mode=0o600):
     planted, which is the point. Treating that EEXIST as fatal would hand the
     same racer an ExecStartPre failure on demand, so the loss costs a retry.
 
-    `replace` is for a value being regenerated rather than created once: the old
-    file is a stale copy of a secret that no longer opens anything, so it goes.
-    Without it the O_EXCL create would fail against the hook's own last run.
+    `replace` is for a name this hook owns and rewrites rather than creates once:
+    a regenerated secret, whose old file no longer opens anything, and the temp
+    files the atomic writes stage through. Without it the O_EXCL create fails
+    against the hook's own last run -- and `clear_unexpected` will not remove the
+    leftover, because a regular file is exactly the type it wants there.
     """
     for _ in range(ATTEMPTS):
         if not clear_unexpected(dfd, name):
@@ -275,8 +279,13 @@ def configure_influx(sk_fd, token):
         if influxes:
             influxes[0]["token"] = token
 
+        # `replace` because this name is one the hook owns and rewrites: without
+        # it, a .tmp left by an interrupted run survives clear_unexpected (a
+        # regular file is the wanted type) and every later O_EXCL create fails
+        # EEXIST, so the token is never refreshed again on that device.
         tmp = name + ".tmp"
-        if not create_guarded(cfg_fd, tmp, json.dumps(cfg, indent=2) + "\n"):
+        if not create_guarded(cfg_fd, tmp, json.dumps(cfg, indent=2) + "\n",
+                              replace=True):
             warn("cannot write %s; leaving the config alone" % tmp)
             return
         os.replace(tmp, name, src_dir_fd=cfg_fd, dst_dir_fd=cfg_fd)
@@ -288,10 +297,19 @@ def configure_influx(sk_fd, token):
 # REMOVE AFTER 2027-08-01. This repairs one closed population -- devices seeded
 # between v0.3.1+13 and the providers/simple fix -- and every boot after the last
 # of them has been repaired, reimaged or retired is a root write into a
-# container-owned directory bought for nothing. Removing it means deleting
-# migrate_gpsd_liner and its call site, the "the gpsd liner migration" scenarios
-# in tools/test-prestart.sh, and the settings.json paragraphs in AGENTS.md, after
-# which settings.json goes back to being a path this hook never writes.
+# container-owned directory bought for nothing. What goes with it:
+#
+#   * migrate_gpsd_liner and its call site
+#   * the `mode` parameter on create_exclusive and create_guarded, and the
+#     paragraph of create_exclusive's docstring that justifies it -- this is the
+#     only caller that passes anything but the default
+#   * the settings.json.pre-liner hand_over below (the settings.json one above it
+#     predates this and stays -- the postinst creates that file root-owned)
+#   * in tools/test-prestart.sh: the "the gpsd liner migration" scenarios, the
+#     element_types helper and the PRE_LINER_SETTINGS fixture
+#   * the settings.json paragraphs in AGENTS.md
+#
+# After which settings.json goes back to being a path this hook never writes.
 def migrate_gpsd_liner(sk_fd):
     """Splice the missing Liner into a gpsd connection seeded before the fix.
 
@@ -316,29 +334,45 @@ def migrate_gpsd_liner(sk_fd):
 
     This is the only writer of settings.json here, and the reason that path needs
     the same discipline as the secret files above: what makes it dangerous is
-    root writing into a directory uid 1000 owns, not the contents. It runs from
-    ExecStartPre with the container stopped, which is the only point where Signal
-    K -- the file's other writer -- provably is not mid-write.
+    root writing into a directory uid 1000 owns, not the contents.
+
+    ExecStartPre is where this belongs because the unit stops the container before
+    it restarts, so Signal K -- the file's other writer -- is normally not running
+    while this rewrites it. Normally, not always: the compose file sets
+    `restart: unless-stopped` and the unit is only `After=docker.service`, so an
+    unclean shutdown leaves the container in dockerd's restore set and it can be
+    up again before this runs. `docker compose up` then attaches to it instead of
+    recreating it, and the server keeps the settings it read at its own start --
+    so on that boot the repair lands on disk without reaching the running server,
+    and takes effect at the next start that actually recreates the container.
     """
     backup = "settings.json.pre-liner"
+
+    # The backup doubles as the record that this already ran, which is what keeps
+    # a repair from becoming a standing policy: an operator who restores the old
+    # connection deliberately would otherwise have it spliced again on the next
+    # boot, with no way to refuse short of uninstalling the package. Checked
+    # before settings.json is opened, so no early return below owns a descriptor.
+    try:
+        os.lstat(backup, dir_fd=sk_fd)
+        return
+    except FileNotFoundError:
+        pass
+
     try:
         fd = open_regular(sk_fd, "settings.json")
     except FileNotFoundError:
         return  # a fresh install has none until the postinst seeds default-data
 
-    # The backup doubles as the record that this already ran, which is what keeps
-    # a repair from becoming a standing policy: an operator who restores the old
-    # connection deliberately would otherwise have it spliced again on the next
-    # boot, with no way to refuse short of uninstalling the package.
-    try:
-        os.lstat(backup, dir_fd=sk_fd)
-        os.close(fd)
-        return
-    except FileNotFoundError:
-        pass
-
-    with os.fdopen(fd) as f:  # owns fd from here, including on failure
-        mode = stat.S_IMODE(os.fstat(f.fileno()).st_mode)
+    # UTF-8 explicitly: settings.json is UTF-8 by specification, and text mode
+    # otherwise decodes it in the process locale. Under a single-byte locale a
+    # vessel name comes back as two characters that json.dumps then re-escapes,
+    # so the rewrite would corrupt a value it was not asked to touch.
+    with os.fdopen(fd, encoding="utf-8") as f:  # owns fd from here
+        # Permission bits only. uid 1000 owns settings.json and chooses its mode,
+        # and S_IMODE keeps setuid and setgid as well -- root would reproduce them
+        # on a file it creates here and, for the backup, never hands over.
+        mode = stat.S_IMODE(os.fstat(f.fileno()).st_mode) & 0o777
         original = f.read()
 
     settings = json.loads(original)
@@ -364,36 +398,35 @@ def migrate_gpsd_liner(sk_fd):
     if not spliced:
         return
 
-    # The original goes down first: it is what the splice is derived from, and a
-    # migration whose backup failed is one the operator cannot undo.
-    if not create_guarded(sk_fd, backup, original, mode=mode):
-        warn("cannot write %s; leaving the gpsd connection alone" % backup)
+    # Not settings.json.tmp: that is the name the server's own atomic write stages
+    # through, so a leftover there is a root-owned file in its way and its next
+    # save fails EACCES.
+    tmp = "settings.json.halos-tmp"
+    body = json.dumps(settings, indent=2) + "\n"
+    if not create_guarded(sk_fd, tmp, body, replace=True, mode=mode):
+        warn("cannot write %s; leaving the gpsd connection alone" % tmp)
         return
 
-    tmp = "settings.json.tmp"
-    body = json.dumps(settings, indent=2) + "\n"
-    migrated = False
-    try:
-        if create_guarded(sk_fd, tmp, body, replace=True, mode=mode):
-            # renameat replaces the name and never follows it, so a symlink
-            # swapped in after the read above is overwritten rather than written
-            # through.
-            os.replace(tmp, "settings.json", src_dir_fd=sk_fd, dst_dir_fd=sk_fd)
-            migrated = True
-        else:
-            warn("cannot write %s; leaving the gpsd connection alone" % tmp)
-    finally:
-        if not migrated:
-            # A backup with no migration behind it reads as one on the next boot
-            # and would retire the repair without ever having made it.
-            try:
-                os.unlink(backup, dir_fd=sk_fd)
-            except OSError as exc:
-                warn("could not remove %s after a failed migration: %s" % (backup, exc))
+    # renameat replaces the name and never follows it, so a symlink swapped in
+    # after the read above is overwritten rather than written through.
+    os.replace(tmp, "settings.json", src_dir_fd=sk_fd, dst_dir_fd=sk_fd)
+    print("Added the missing providers/liner to the gpsd connection")
 
-    if migrated:
-        print("Added the missing providers/liner to the gpsd connection")
+    # The record of the repair goes down after the repair, never before. Anything
+    # that stops the hook above this line leaves settings.json untouched and no
+    # backup, so the next boot tries again; stopping below it costs the undo copy
+    # and not the repair. Ordering it the other way makes a half-written backup
+    # read as a completed migration and retires the device for good.
+    # Caught here rather than at the call site: by this point the repair has
+    # landed, and the call site's handler would report it as not migrated.
+    try:
+        kept = create_guarded(sk_fd, backup, original, mode=mode)
+    except OSError as exc:
+        kept = False
+        warn("could not keep a copy of the previous connection: %s" % exc)
+    if kept:
         print("The connection as it was is kept at %s/%s" % (SK_DATA, backup))
+        print("Leave that file in place: it also stops this running again")
 
 
 sk_fd = open_dir(SK_DATA)
@@ -508,6 +541,11 @@ if [ -f "${SECURITY_FILE}" ]; then
 fi
 if [ -f "${SIGNALK_DATA}/settings.json" ]; then
     hand_over "${SIGNALK_DATA}/settings.json"
+fi
+# The migration writes this one as root, and it is the file the operator is told
+# to copy back. Left root-owned, that instruction needs a shell on the host.
+if [ -f "${SIGNALK_DATA}/settings.json.pre-liner" ]; then
+    hand_over "${SIGNALK_DATA}/settings.json.pre-liner"
 fi
 
 # The app store installs plugin updates into this tree as uid 1000, and that is

--- a/run
+++ b/run
@@ -82,12 +82,12 @@ function test {
   #@ Run test suite in Docker container
   #@ Category: Testing
   echo "🧪 Running tests..."
-  # pytest runs as nobody, not as root. tools/test-prestart.sh asserts that the
-  # hook refuses to start when it cannot make security.json safe, and that a data
-  # directory it cannot write leaves the gpsd connection alone -- both staged with
-  # chmod 555, which root ignores. As root those scenarios pass silently against a
-  # hook that did the opposite. CI runs unprivileged on the runner and never saw
-  # this; only ./run test did.
+  # pytest runs as nobody, not as root. Several tools/test-prestart.sh scenarios
+  # stage an unwritable path with chmod 555, which root ignores, so as root they
+  # assert against a condition that never happened: two fail and one passes
+  # without exercising anything. The harness now refuses a root run outright, so
+  # without this the whole suite stops here. CI runs unprivileged on the runner
+  # and never hit it; only ./run test did.
   docker run --rm -v "$(pwd):/workspace" -w /workspace python:3.11-slim \
     bash -c "pip install -q -r tests/requirements.txt \
       && runuser -u nobody -- python -m pytest tests/ -v"

--- a/run
+++ b/run
@@ -82,8 +82,15 @@ function test {
   #@ Run test suite in Docker container
   #@ Category: Testing
   echo "🧪 Running tests..."
+  # pytest runs as nobody, not as root. tools/test-prestart.sh asserts that the
+  # hook refuses to start when it cannot make security.json safe, and that a data
+  # directory it cannot write leaves the gpsd connection alone -- both staged with
+  # chmod 555, which root ignores. As root those scenarios pass silently against a
+  # hook that did the opposite. CI runs unprivileged on the runner and never saw
+  # this; only ./run test did.
   docker run --rm -v "$(pwd):/workspace" -w /workspace python:3.11-slim \
-    bash -c "pip install -q -r tests/requirements.txt && python -m pytest tests/ -v"
+    bash -c "pip install -q -r tests/requirements.txt \
+      && runuser -u nobody -- python -m pytest tests/ -v"
 }
 
 function test:watch {

--- a/tests/test_signalk_prestart.py
+++ b/tests/test_signalk_prestart.py
@@ -154,6 +154,26 @@ def test_prestart_chown_is_scoped():
         )
 
 
+def test_prestart_masks_an_inherited_mode_to_permission_bits():
+    """The migration copies settings.json's mode onto the files it creates, and
+    uid 1000 owns settings.json -- so the container chooses that mode.
+
+    `stat.S_IMODE` is `mode & 0o7777`, which keeps setuid and setgid. Root then
+    reproduces them on settings.json.pre-liner, a file it creates and never hands
+    over, so nothing clears them afterwards. Guarded here rather than in
+    tools/test-prestart.sh because that harness cannot see it: it refuses to run
+    as root, and the kernel strips those bits for any writer without CAP_FSETID.
+    """
+    prestart = hook_code()
+
+    calls = [line for line in prestart.splitlines() if "stat.S_IMODE(" in line]
+    assert calls, "no S_IMODE call parsed -- the guard would pass vacuously"
+    for line in calls:
+        assert "& 0o777" in line, (
+            f"an inherited mode reaches a root create unmasked: {line.strip()}"
+        )
+
+
 def test_prestart_does_not_gate_influxdb_on_the_data_volume():
     """The plugin lives in the image, so the data volume cannot attest to it.
 

--- a/tools/test-prestart.sh
+++ b/tools/test-prestart.sh
@@ -3,7 +3,8 @@
 #
 # The hook writes three files holding secrets. Their modes are a property of the
 # filesystem after it runs, not of the script's text, so this runs it against a
-# sandbox: no root, no container, no InfluxDB.
+# sandbox: no container, no InfluxDB, and deliberately not as root -- see the
+# refusal below.
 #
 # Modes are asserted against the real filesystem. Ownership is asserted against
 # the chown stub's call log -- the run is unprivileged, so no uid here can ever
@@ -18,6 +19,16 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 HOOK="${REPO_ROOT}/apps/signalk-server/prestart.sh"
 REAL_PYTHON3="$(command -v python3)"
 export REAL_PYTHON3
+
+# Several scenarios stage their condition with chmod 555, which root ignores.
+# Run as root the suite is neither green nor usefully red: two of them fail with
+# nothing pointing at the environment, and one passes without exercising the
+# failure it names. Refuse rather than report either.
+if [ "$(id -u)" = "0" ]; then
+    echo "tools/test-prestart.sh must not run as root: the scenarios staged with" >&2
+    echo "chmod 555 cannot be staged against a caller that ignores file modes." >&2
+    exit 1
+fi
 pass=0
 fail=0
 
@@ -35,12 +46,37 @@ mode() {
 # The pipeline as the file spells it, in order. Asserting on the whole sequence
 # rather than grepping for "providers/liner": a liner spliced at the wrong index
 # leaves the grep green and the connection just as broken.
-element_types() {  # $1 = a settings.json
+#
+# Failures print ERROR rather than going to /dev/null. Swallowing them makes a
+# missing or unparseable file indistinguishable from an empty pipeline, so an
+# expectation that was ever empty would pass against a hook that deleted the file.
+element_types() {  # $1 = a settings.json, $2 = index into pipedProviders (default 0)
     "${REAL_PYTHON3}" -c '
 import json, sys
-s = json.load(open(sys.argv[1]))
-print(" ".join(e.get("type", "?") for e in s["pipedProviders"][0]["pipeElements"]))
-' "$1" 2>/dev/null
+try:
+    settings = json.load(open(sys.argv[1]))
+    provider = settings["pipedProviders"][int(sys.argv[2])]
+    print(" ".join(e.get("type", "?") for e in provider["pipeElements"]))
+except Exception as exc:
+    print("ERROR: %s" % exc)
+' "$1" "${2:-0}"
+}
+
+# The migration round-trips the whole document through json.loads/json.dumps, and
+# the element-type assertions above only look at one provider's pipeline. A
+# rewrite that dropped the vessel uuid, the mmsi or the interfaces settings would
+# pass every one of them, so this compares everything else against the copy the
+# hook kept: remove the liners from the migrated file and it must equal it.
+migration_changed_nothing_else() {  # $1 = migrated settings.json, $2 = the backup
+    "${REAL_PYTHON3}" -c '
+import json, sys
+migrated = json.load(open(sys.argv[1]))
+before = json.load(open(sys.argv[2]))
+for provider in migrated.get("pipedProviders", []):
+    provider["pipeElements"] = [e for e in provider["pipeElements"]
+                                if e.get("type") != "providers/liner"]
+sys.exit(0 if migrated == before else 1)
+' "$1" "$2"
 }
 
 # What every device seeded from v0.3.1+13 onward carries: gpsd piped straight
@@ -172,12 +208,13 @@ chowned() {  # $1 = path the hook must have handed to the container uid
 # anything planted from bcrypt lands *before* the clear and is simply removed --
 # which is how the two racer scenarios silently became no-ops. Wrapping os.open
 # is inside the window by construction, and stays there if the order changes.
-inject_before_open() {  # $1 = True for the create, False for the read; $2 = sh
+inject_before_open() {  # $1 = True for the create, False for the read; $2 = sh;
+                        # $3 = the name to fire on (default security.json)
     cat > "${SANDBOX}/pylib/sitecustomize.py" <<SHIM
 import os, subprocess
 _real, _fired = os.open, []
 def _open(path, flags, mode=0o777, *, dir_fd=None):
-    if path == "security.json" and not _fired and bool(flags & os.O_CREAT) is ${1}:
+    if path == "${3:-security.json}" and not _fired and bool(flags & os.O_CREAT) is ${1}:
         _fired.append(True)
         subprocess.run(["sh", "-c", r"""${2}"""])
     return _real(path, flags, mode, dir_fd=dir_fd)
@@ -683,18 +720,44 @@ check "  the liner lands between the two elements" \
     "$(element_types "${SK}/settings.json")" \
     "providers/gpsd providers/liner providers/nmea0183-signalk"
 check "  and the file keeps its mode" "$(mode "${SK}/settings.json")" "644"
-grep -q reconnectInterval "${SK}/settings.json" &&
-    ok "  the gpsd options are carried over" ||
-    bad "  the gpsd options are carried over" "$(cat "${SK}/settings.json")"
+# The whole document, not just the pipeline: the rewrite serialises every key in
+# the file, and a fielded settings.json carries the vessel uuid and mmsi, the
+# interfaces settings and the ssl flag alongside pipedProviders.
+migration_changed_nothing_else "${SK}/settings.json" "${SK}/settings.json.pre-liner" &&
+    ok "  and nothing else in the document changes" ||
+    bad "  and nothing else in the document changes" "$(cat "${SK}/settings.json")"
 check "  the original is kept alongside" \
     "$(element_types "${SK}/settings.json.pre-liner")" \
     "providers/gpsd providers/nmea0183-signalk"
+# The backup is what the operator is told to copy back. Landed 0600 it is
+# unreadable to the uid that would restore it, and the instruction is dead.
+check "  at the mode the original had" "$(mode "${SK}/settings.json.pre-liner")" "644"
 # Root replaced a file the container owns and writes. Left root-owned, every
 # later change made in the admin UI fails and the connection cannot be edited or
 # deleted -- a repair that costs the operator the tool for repairing it.
 chowned "${SK}/settings.json" &&
     ok "  and the rewritten file is handed back to the container" ||
     bad "  and the rewritten file is handed back to the container" "$(cat "${STUB_LOG}")"
+chowned "${SK}/settings.json.pre-liner" &&
+    ok "  as is the copy it kept" ||
+    bad "  as is the copy it kept" "$(cat "${STUB_LOG}")"
+teardown
+
+# A device with a real NMEA connection alongside the gpsd one. The splice walks
+# every provider, so the match cannot be pinned by a fixture that only ever has
+# one -- narrowing the loop to pipedProviders[0] would pass every scenario above.
+setup
+printf '%s\n' '{"pipedProviders":[
+  {"id":"n2k","pipeElements":[{"type":"providers/simple","options":{"type":"NMEA2000"}}]},
+  {"id":"gpsd","pipeElements":[
+    {"type":"providers/gpsd","options":{"hostname":"localhost"}},
+    {"type":"providers/nmea0183-signalk"}]}]}' > "${SK}/settings.json"
+check "a gpsd connection that is not the first is migrated" "$(run_hook)" "0"
+check "  the other connection is untouched" \
+    "$(element_types "${SK}/settings.json" 0)" "providers/simple"
+check "  and the gpsd one gets the liner" \
+    "$(element_types "${SK}/settings.json" 1)" \
+    "providers/gpsd providers/liner providers/nmea0183-signalk"
 teardown
 
 # The hook runs on every boot, so the predicate has to stop matching what it
@@ -757,29 +820,61 @@ check "  and its mode" "$(mode "${CANARY}")" "644"
 teardown
 
 # The rewrite lands through a sibling temp file, and uid 1000 owns the directory
-# -- so .tmp is a name root writes that no path guard covers unless the create
+# -- so that name is one root writes that no path guard covers unless the create
 # itself refuses to follow it.
 setup
 CANARY="${SANDBOX}/outside-the-data-root"
 printf 'original\n' > "${CANARY}"; chmod 644 "${CANARY}"
 printf '%s\n' "${PRE_LINER_SETTINGS}" > "${SK}/settings.json"
-ln -s "${CANARY}" "${SK}/settings.json.tmp"
-check "a symlinked .tmp does not redirect the migration" "$(run_hook)" "0"
+ln -s "${CANARY}" "${SK}/settings.json.halos-tmp"
+check "a symlinked temp path does not redirect the migration" "$(run_hook)" "0"
 check "  the link target is not written through" "$(cat "${CANARY}")" "original"
 check "  and the connection is still migrated" \
     "$(element_types "${SK}/settings.json")" \
     "providers/gpsd providers/liner providers/nmea0183-signalk"
 teardown
 
-# The backup is the second name root writes here, and it carries the whole
-# pre-migration file -- a redirected copy overwrites the target with it.
+# settings.json.tmp belongs to the server: atomicWriteFile stages every one of
+# its own saves through it. A root-owned file left at that name fails the
+# container's next write with EACCES, so the hook must not use it at all.
+setup
+printf '%s\n' "${PRE_LINER_SETTINGS}" > "${SK}/settings.json"
+printf 'the servers own staging file\n' > "${SK}/settings.json.tmp"
+check "the server's own .tmp name is left alone" "$(run_hook)" "0"
+check "  its contents are untouched" "$(cat "${SK}/settings.json.tmp")" \
+    "the servers own staging file"
+[ ! -e "${SK}/settings.json.halos-tmp" ] &&
+    ok "  and the hook's staging file does not survive" ||
+    bad "  and the hook's staging file does not survive" "halos-tmp was left behind"
+teardown
+
+# The backup carries the whole pre-migration file, so a redirected copy
+# overwrites the link target with it. Planted inside the window rather than
+# before the run: the sentinel check lstats this name first, so a symlink staged
+# up front is a hit and the hook returns before the create is ever reached --
+# which is the shape this scenario had until review caught it passing vacuously.
 setup
 CANARY="${SANDBOX}/outside-the-data-root"
 printf 'original\n' > "${CANARY}"; chmod 644 "${CANARY}"
 printf '%s\n' "${PRE_LINER_SETTINGS}" > "${SK}/settings.json"
-ln -s "${CANARY}" "${SK}/settings.json.pre-liner"
-check "a symlinked backup path does not redirect the copy" "$(run_hook)" "0"
+inject_before_open True "ln -sfn '${CANARY}' '${SK}/settings.json.pre-liner'" \
+    settings.json.pre-liner
+check "a backup path planted after the clear does not redirect the copy" "$(run_hook)" "0"
 check "  the link target is not written through" "$(cat "${CANARY}")" "original"
+check "  and the repair still stands" \
+    "$(element_types "${SK}/settings.json")" \
+    "providers/gpsd providers/liner providers/nmea0183-signalk"
+teardown
+
+# A symlink already at that name before the run is the refusal path, not the
+# write path: the sentinel means "this already ran", whatever the file is.
+setup
+printf '%s\n' "${PRE_LINER_SETTINGS}" > "${SK}/settings.json"
+ln -s /nonexistent "${SK}/settings.json.pre-liner"
+check "anything at the backup name refuses the repair" "$(run_hook)" "0"
+check "  the connection is left as it was" \
+    "$(element_types "${SK}/settings.json")" \
+    "providers/gpsd providers/nmea0183-signalk"
 teardown
 
 # Restoring the backup is how an operator refuses the repair. Without it standing
@@ -795,9 +890,24 @@ check "  the restore survives the next boot" \
     "providers/gpsd providers/nmea0183-signalk"
 teardown
 
-# The other half of that: the backup only means "already migrated" if a run that
-# wrote it and then failed takes it away again. Left behind, one failed boot
-# retires the repair on that device without ever having made it.
+# Restoring with mv takes the record away with the copy, so the splice runs
+# again. Pinned rather than fixed: the hook prints that the file has to stay, and
+# a record separate from the backup would be a second file on every device for a
+# gesture the message already covers.
+setup
+printf '%s\n' "${PRE_LINER_SETTINGS}" > "${SK}/settings.json"
+run_hook > /dev/null
+mv "${SK}/settings.json.pre-liner" "${SK}/settings.json"
+check "restoring with mv re-arms the splice" "$(run_hook)" "0"
+check "  the connection is migrated again" \
+    "$(element_types "${SK}/settings.json")" \
+    "providers/gpsd providers/liner providers/nmea0183-signalk"
+teardown
+
+# The repair goes down before the record of it, so a failure at the rename leaves
+# settings.json untouched and nothing claiming the migration ran. Ordered the
+# other way, this boot would retire the device: the next one reads the backup as
+# a completed migration and never looks at the connection again.
 setup
 printf '%s\n' "${PRE_LINER_SETTINGS}" > "${SK}/settings.json"
 cat > "${SANDBOX}/pylib/sitecustomize.py" <<'SHIM'
@@ -814,11 +924,36 @@ check "  the connection is left as it was" \
     "$(element_types "${SK}/settings.json")" \
     "providers/gpsd providers/nmea0183-signalk"
 [ ! -e "${SK}/settings.json.pre-liner" ] &&
-    ok "  and no backup is left to retire the retry" ||
-    bad "  and no backup is left to retire the retry" "a backup survived the failure"
+    ok "  and nothing is left claiming it ran" ||
+    bad "  and nothing is left claiming it ran" "a backup survived the failure"
 rm -f "${SANDBOX}/pylib/sitecustomize.py"
 check "  so a later boot still migrates it" "$(run_hook)" "0"
 check "  with the liner where it belongs" \
+    "$(element_types "${SK}/settings.json")" \
+    "providers/gpsd providers/liner providers/nmea0183-signalk"
+teardown
+
+# The other end of that order: the repair has landed and only the copy fails. The
+# device is fixed, so the next boot must not splice a second liner -- the file no
+# longer matching is what carries idempotency here, not the record.
+setup
+printf '%s\n' "${PRE_LINER_SETTINGS}" > "${SK}/settings.json"
+cat > "${SANDBOX}/pylib/sitecustomize.py" <<'SHIM'
+import errno, os
+_real = os.open
+def _open(path, flags, mode=0o777, *, dir_fd=None):
+    if path == "settings.json.pre-liner" and (flags & os.O_CREAT):
+        raise OSError(errno.ENOSPC, "No space left on device")
+    return _real(path, flags, mode, dir_fd=dir_fd)
+os.open = _open
+SHIM
+check "a failed backup does not cost the repair" "$(run_hook)" "0"
+check "  the connection is migrated" \
+    "$(element_types "${SK}/settings.json")" \
+    "providers/gpsd providers/liner providers/nmea0183-signalk"
+rm -f "${SANDBOX}/pylib/sitecustomize.py"
+check "  and the next boot adds no second liner" "$(run_hook)" "0"
+check "  the pipeline still has exactly one" \
     "$(element_types "${SK}/settings.json")" \
     "providers/gpsd providers/liner providers/nmea0183-signalk"
 teardown

--- a/tools/test-prestart.sh
+++ b/tools/test-prestart.sh
@@ -32,6 +32,46 @@ mode() {
         'import os, sys; print(format(os.stat(sys.argv[1]).st_mode & 0o777, "03o"))' "$1"
 }
 
+# The pipeline as the file spells it, in order. Asserting on the whole sequence
+# rather than grepping for "providers/liner": a liner spliced at the wrong index
+# leaves the grep green and the connection just as broken.
+element_types() {  # $1 = a settings.json
+    "${REAL_PYTHON3}" -c '
+import json, sys
+s = json.load(open(sys.argv[1]))
+print(" ".join(e.get("type", "?") for e in s["pipedProviders"][0]["pipeElements"]))
+' "$1" 2>/dev/null
+}
+
+# What every device seeded from v0.3.1+13 onward carries: gpsd piped straight
+# into the parser. gpsd writes a whole NMEA reporting cycle in one TCP write, so
+# with no splitter between them the parser rejects every burst and no position
+# ever reaches Signal K.
+PRE_LINER_SETTINGS='{
+  "ssl": false,
+  "trustProxy": true,
+  "pipedProviders": [
+    {
+      "id": "gpsd",
+      "pipeElements": [
+        {
+          "type": "providers/gpsd",
+          "options": {
+            "hostname": "localhost",
+            "port": 2947,
+            "noDataReceivedTimeout": 30,
+            "reconnectInterval": 15
+          }
+        },
+        {
+          "type": "providers/nmea0183-signalk"
+        }
+      ],
+      "enabled": true
+    }
+  ]
+}'
+
 setup() {
     SANDBOX="$(mktemp -d)"
     DATA="${SANDBOX}/data"
@@ -627,6 +667,187 @@ run_hook > /dev/null
 chowned "${SK}/settings.json" &&
     ok "settings.json is handed over" ||
     bad "settings.json is handed over" "$(cat "${STUB_LOG}")"
+teardown
+
+# --- the gpsd liner migration ------------------------------------------------
+#
+# default-data is copy-if-absent, so correcting the baked connection reached new
+# installs only. These devices are already shipped, and nothing else in the
+# package ever rewrites the file they were seeded with.
+
+setup
+printf '%s\n' "${PRE_LINER_SETTINGS}" > "${SK}/settings.json"
+chmod 644 "${SK}/settings.json"
+check "a pre-liner gpsd connection is migrated" "$(run_hook)" "0"
+check "  the liner lands between the two elements" \
+    "$(element_types "${SK}/settings.json")" \
+    "providers/gpsd providers/liner providers/nmea0183-signalk"
+check "  and the file keeps its mode" "$(mode "${SK}/settings.json")" "644"
+grep -q reconnectInterval "${SK}/settings.json" &&
+    ok "  the gpsd options are carried over" ||
+    bad "  the gpsd options are carried over" "$(cat "${SK}/settings.json")"
+check "  the original is kept alongside" \
+    "$(element_types "${SK}/settings.json.pre-liner")" \
+    "providers/gpsd providers/nmea0183-signalk"
+# Root replaced a file the container owns and writes. Left root-owned, every
+# later change made in the admin UI fails and the connection cannot be edited or
+# deleted -- a repair that costs the operator the tool for repairing it.
+chowned "${SK}/settings.json" &&
+    ok "  and the rewritten file is handed back to the container" ||
+    bad "  and the rewritten file is handed back to the container" "$(cat "${STUB_LOG}")"
+teardown
+
+# The hook runs on every boot, so the predicate has to stop matching what it
+# produced. A second liner is not cosmetic: it splits already-split lines and the
+# connection stays broken, now with no trace of what did it.
+setup
+printf '%s\n' "${PRE_LINER_SETTINGS}" > "${SK}/settings.json"
+run_hook > /dev/null
+MIGRATED="$(cat "${SK}/settings.json")"
+check "an already-migrated connection is left alone" "$(run_hook)" "0"
+check "  byte for byte" "$(cat "${SK}/settings.json")" "${MIGRATED}"
+check "  with no second liner" "$(element_types "${SK}/settings.json")" \
+    "providers/gpsd providers/liner providers/nmea0183-signalk"
+teardown
+
+# What the admin UI writes, and what a new install now seeds. The server
+# assembles the pipeline from this, so there is nothing to splice -- and a device
+# that was repaired by deleting and recreating the connection looks like this.
+setup
+cp "${REPO_ROOT}/apps/signalk-server/default-data/data/settings.json" "${SK}/settings.json"
+BEFORE="$(cat "${SK}/settings.json")"
+check "a providers/simple connection is left alone" "$(run_hook)" "0"
+check "  unchanged" "$(cat "${SK}/settings.json")" "${BEFORE}"
+[ ! -e "${SK}/settings.json.pre-liner" ] &&
+    ok "  and nothing is backed up" ||
+    bad "  and nothing is backed up" "a backup was written"
+teardown
+
+# The adjacency is the whole predicate, and that is what makes it also the
+# unmodified check. gpsd piped into anything else is someone's own pipeline.
+setup
+printf '%s\n' '{"pipedProviders":[{"id":"gpsd","pipeElements":[
+  {"type":"providers/gpsd"},{"type":"providers/log"},
+  {"type":"providers/nmea0183-signalk"}]}]}' > "${SK}/settings.json"
+BEFORE="$(cat "${SK}/settings.json")"
+check "a pipeline we did not ship is left alone" "$(run_hook)" "0"
+check "  unchanged" "$(cat "${SK}/settings.json")" "${BEFORE}"
+teardown
+
+# A fresh install has no settings.json until the postinst seeds default-data.
+# Writing one here would bake a shape from this hook that default-data owns.
+setup
+check "no settings.json is invented when none exists" "$(run_hook)" "0"
+[ ! -e "${SK}/settings.json" ] &&
+    ok "  none is written" || bad "  none is written" "$(cat "${SK}/settings.json")"
+teardown
+
+# This is the first thing in the hook that ever writes settings.json, so the swap
+# the secret files are hardened against now reaches this path too. The link
+# target is a valid pre-liner config on purpose: pointed at plain text, a hook
+# that followed the link would fail on the parse and look guarded.
+setup
+CANARY="${SANDBOX}/outside-the-data-root"
+printf '%s\n' "${PRE_LINER_SETTINGS}" > "${CANARY}"; chmod 644 "${CANARY}"
+ln -s "${CANARY}" "${SK}/settings.json"
+check "a symlinked settings.json is not migrated through the link" "$(run_hook)" "0"
+check "  the link target keeps its two elements" \
+    "$(element_types "${CANARY}")" "providers/gpsd providers/nmea0183-signalk"
+check "  and its mode" "$(mode "${CANARY}")" "644"
+teardown
+
+# The rewrite lands through a sibling temp file, and uid 1000 owns the directory
+# -- so .tmp is a name root writes that no path guard covers unless the create
+# itself refuses to follow it.
+setup
+CANARY="${SANDBOX}/outside-the-data-root"
+printf 'original\n' > "${CANARY}"; chmod 644 "${CANARY}"
+printf '%s\n' "${PRE_LINER_SETTINGS}" > "${SK}/settings.json"
+ln -s "${CANARY}" "${SK}/settings.json.tmp"
+check "a symlinked .tmp does not redirect the migration" "$(run_hook)" "0"
+check "  the link target is not written through" "$(cat "${CANARY}")" "original"
+check "  and the connection is still migrated" \
+    "$(element_types "${SK}/settings.json")" \
+    "providers/gpsd providers/liner providers/nmea0183-signalk"
+teardown
+
+# The backup is the second name root writes here, and it carries the whole
+# pre-migration file -- a redirected copy overwrites the target with it.
+setup
+CANARY="${SANDBOX}/outside-the-data-root"
+printf 'original\n' > "${CANARY}"; chmod 644 "${CANARY}"
+printf '%s\n' "${PRE_LINER_SETTINGS}" > "${SK}/settings.json"
+ln -s "${CANARY}" "${SK}/settings.json.pre-liner"
+check "a symlinked backup path does not redirect the copy" "$(run_hook)" "0"
+check "  the link target is not written through" "$(cat "${CANARY}")" "original"
+teardown
+
+# Restoring the backup is how an operator refuses the repair. Without it standing
+# in for "this already ran", the next boot splices the connection again and there
+# is no way to say no short of uninstalling the package.
+setup
+printf '%s\n' "${PRE_LINER_SETTINGS}" > "${SK}/settings.json"
+run_hook > /dev/null
+cp "${SK}/settings.json.pre-liner" "${SK}/settings.json"
+check "a restored pre-liner connection is left alone" "$(run_hook)" "0"
+check "  the restore survives the next boot" \
+    "$(element_types "${SK}/settings.json")" \
+    "providers/gpsd providers/nmea0183-signalk"
+teardown
+
+# The other half of that: the backup only means "already migrated" if a run that
+# wrote it and then failed takes it away again. Left behind, one failed boot
+# retires the repair on that device without ever having made it.
+setup
+printf '%s\n' "${PRE_LINER_SETTINGS}" > "${SK}/settings.json"
+cat > "${SANDBOX}/pylib/sitecustomize.py" <<'SHIM'
+import errno, os
+_real = os.replace
+def _replace(src, dst, *, src_dir_fd=None, dst_dir_fd=None):
+    if dst == "settings.json":
+        raise OSError(errno.EIO, "Input/output error")
+    return _real(src, dst, src_dir_fd=src_dir_fd, dst_dir_fd=dst_dir_fd)
+os.replace = _replace
+SHIM
+check "a migration that fails at the rename does not block the start" "$(run_hook)" "0"
+check "  the connection is left as it was" \
+    "$(element_types "${SK}/settings.json")" \
+    "providers/gpsd providers/nmea0183-signalk"
+[ ! -e "${SK}/settings.json.pre-liner" ] &&
+    ok "  and no backup is left to retire the retry" ||
+    bad "  and no backup is left to retire the retry" "a backup survived the failure"
+rm -f "${SANDBOX}/pylib/sitecustomize.py"
+check "  so a later boot still migrates it" "$(run_hook)" "0"
+check "  with the liner where it belongs" \
+    "$(element_types "${SK}/settings.json")" \
+    "providers/gpsd providers/liner providers/nmea0183-signalk"
+teardown
+
+# A settings.json that will not parse is one Signal K cannot start from either.
+# Rewriting it from a guess is worse than leaving it for the operator.
+setup
+printf 'not json at all\n' > "${SK}/settings.json"
+check "an unparseable settings.json does not block the start" "$(run_hook)" "0"
+check "  and is left as it was" "$(cat "${SK}/settings.json")" "not json at all"
+grep -q "gpsd connection not migrated" "${SANDBOX}/out" &&
+    ok "  and the reason is logged" ||
+    bad "  and the reason is logged" "$(cat "${SANDBOX}/out")"
+teardown
+
+# The migration is a repair, not a precondition. A device that keeps the old
+# connection shows no position, which is where it already was; a device whose
+# ExecStartPre aborts has no navigation server at all. The licence to refuse to
+# start belongs to security.json alone.
+setup
+printf '{"users":[]}\n' > "${SK}/security.json"
+printf '%s\n' "${PRE_LINER_SETTINGS}" > "${SK}/settings.json"
+chmod 555 "${SK}"
+STATUS="$(run_hook)"
+chmod 755 "${SK}"
+check "an unwritable data directory does not block the start" "${STATUS}" "0"
+check "  and the connection is left as it was" \
+    "$(element_types "${SK}/settings.json")" \
+    "providers/gpsd providers/nmea0183-signalk"
 teardown
 
 # Every other scenario asserts the hook exits 0, so nothing pins the deliberate


### PR DESCRIPTION
## The problem

#222 fixed the baked gpsd connection, but `default-data/` is copy-if-absent — the generated postinst copies a file only `if [ ! -f "$dst_file" ]`. Every device seeded from **v0.3.1+13** onward keeps the connection it was first given: `providers/gpsd` piped straight into `providers/nmea0183-signalk`, with no line splitter. gpsd writes a whole NMEA reporting cycle in one TCP write, so the parser gets several sentences as one blob and rejects all of them. No position, at any server version, and `apt` reports success while the app version bumps.

Those devices are shipped. Nothing in the package rewrites the file they carry.

## The change

`prestart.sh` splices a `providers/liner` between the two elements when they are adjacent, keeping the file as it was at `settings.json.pre-liner`.

**The adjacency is the whole predicate, and it doubles as the unmodified check.** The server marks only a single `providers/simple` element editable, so the hand-authored connection rendered in the admin UI as a read-only textarea whose one action is Delete — no device reached this shape by being configured. A connection recreated through the UI is one `providers/simple` element; a hand-repaired one already has three. Neither matches.

**Only the liner goes in.** Rewriting the connection to `providers/simple` — what a new install now seeds — would discard a hand-edited host or port and change the connection's identity in the admin UI. That is adopting the shape we prefer today, not repairing the defect we shipped.

**The record of the repair is written after the repair.** The backup doubles as that record, so restoring it is how an operator refuses; without a record, a deliberate restore would be re-spliced on the next boot. Ordering it first is what would make a partial write fatal — the next boot reads a half-written file as a completed migration and never looks at the connection again. In this order, a failure before the rename leaves `settings.json` untouched and nothing claiming the migration ran; one after it costs the undo copy, not the repair. Idempotency does not rest on the record at all: the migrated file no longer matches the predicate.

**Failure warns, never refuses to start.** A device left on the old connection shows no position, which is where it already was; a device whose `ExecStartPre` aborts has no navigation server at all. The licence to refuse belongs to `security.json` alone.

## Why here and not in the postinst

`ExecStartPre` runs after the unit stops the container, so Signal K — the file's other writer — is normally not running while this rewrites the file. The postinst runs while the container may still be up, and the generator owns it end to end; there is no app-level hook in it.

"Normally" is doing real work in that sentence. `restart: unless-stopped` in the compose file plus a bare `After=docker.service` on the unit means an unclean shutdown leaves the container in dockerd's restore set, and it can be up again before the hook runs. `docker compose up` then attaches instead of recreating, so the repair reaches disk without reaching the running server and takes effect at the next start that recreates the container. Documented rather than defended against.

## The security consequence

This is the first thing in the hook that ever writes `settings.json`, which AGENTS.md listed as safe precisely because nothing did. The file holds no secret — what makes the path dangerous is only that root writes into a directory uid 1000 owns. It goes through the same descriptor-relative `O_EXCL` create and `renameat` as the secret files, and the temp and backup names are covered by those creates rather than by a guard that lists them.

Two consequences that took review to find. The staging file is `settings.json.halos-tmp`, not `settings.json.tmp` — the latter is where the server's own `atomicWriteFile` stages every save, so a root-owned leftover there fails the container's next write with EACCES. And the mode inherited from `settings.json` is masked to permission bits: `S_IMODE` keeps setuid and setgid, and uid 1000 picks that mode, so a bit it set was being reproduced on a root-owned backup that is never chowned.

## Expiry

The population is closed, so the hook carries a `REMOVE AFTER 2027-08-01` marker listing everything that goes with it — the function and its call site, the `mode` parameter added to the shared create helpers, the backup's `hand_over`, the harness scenarios and their fixtures, and the AGENTS.md paragraphs.

## Verified

140 harness scenarios and 37 pytest tests, run unprivileged. The harness now refuses a root run outright.

Seven mutations of the migration were checked against the suite and all seven fail it: dropping every key but `pipedProviders` from the rewrite, narrowing the splice to the first provider, dropping the backup's mode, making the backup create follow symlinks, going back to the server's `.tmp` name, writing the record before the repair, and leaving the inherited mode unmasked. The last is invisible to the harness — it runs unprivileged, and the kernel strips setuid for a writer without `CAP_FSETID` — so it is guarded at source level in `tests/test_signalk_prestart.py`.

## Fly-by

`./run test` ran the container as root, where `chmod 555` does nothing, so the scenarios that assert what the hook does when it *cannot* write were asserting against a condition that never happened. It now runs pytest as `nobody`, and the harness refuses root rather than reporting either a confusing failure or a vacuous pass. Separate commit.

## Not addressed here

- **#225** — nothing ties the `providers/liner` string, or the baked `providers/simple`, to the pinned image. An unresolvable type drops the whole connection, which looks exactly like the bug being repaired. The obvious check always skips in CI (pytest runs on the runner with no docker socket).
- **#226** — the harness's `sitecustomize` shims shadow Homebrew python's own, so 10 scenarios fail locally on macOS for reasons unrelated to the hook. Pre-existing.

`Refs #223` rather than `Closes`: #223's main body asks for this migration, but its trailing note about the untested type string stays open as #225.
