### PR TITLE
Add QuestDB container app

### DIFF
--- a/apps/questdb/config.yml
+++ b/apps/questdb/config.yml
@@ -1,0 +1,17 @@
+version: "1.0"
+
+groups:
+  - id: resources
+    label: Resource Limits
+    description: Caps applied to the QuestDB container
+    fields:
+      - id: QUESTDB_MEMORY_LIMIT
+        label: Memory Limit
+        type: string
+        default: 768m
+        required: true
+        description: >-
+          Hard memory cap for the container (e.g. 512m, 1g, 2g). QuestDB's JVM
+          sizes its heap from this, so it bounds total memory rather than heap
+          alone. The default suits a device running the full marine stack;
+          raise it on hardware with memory to spare.

--- a/apps/questdb/docker-compose.yml
+++ b/apps/questdb/docker-compose.yml
@@ -8,11 +8,18 @@ services:
       driver: journald
       options:
         tag: "{{.Name}}"
-    # Only the HTTP port needs to leave the container: Signal K runs with host
-    # networking and reaches it on loopback, and Traefik reaches it over
-    # halos-proxy-network (auto-injected). ILP and the PostgreSQL wire protocol
-    # take any caller with no credential, so they stay on loopback and get no
-    # Traefik router.
+    # Loopback only: Signal K runs with host networking and reaches these on
+    # 127.0.0.1, and nothing else on the boat network should reach a database
+    # that authenticates none of its three protocols. Only the HTTP port gets a
+    # Traefik router, behind Authelia.
+    #
+    # This bounds the HOST interfaces and nothing else. The generator injects
+    # halos-proxy-network (routing.py: join_proxy_network is true for every app
+    # that is not host-networked), it is a plain bridge, and Docker port
+    # publication does not gate container-to-container traffic -- so any app
+    # container on that network reaches all three ports directly, Traefik and
+    # Authelia not involved. QuestDB is the first datastore here with no
+    # credential of its own to fall back on.
     ports:
       - "127.0.0.1:9000:9000"
       - "127.0.0.1:9009:9009"

--- a/apps/questdb/docker-compose.yml
+++ b/apps/questdb/docker-compose.yml
@@ -1,0 +1,62 @@
+services:
+  questdb:
+    image: questdb/questdb:10.0.0
+    container_name: questdb
+    init: true
+    restart: unless-stopped
+    logging:
+      driver: journald
+      options:
+        tag: "{{.Name}}"
+    # Only the HTTP port needs to leave the container: Signal K runs with host
+    # networking and reaches it on loopback, and Traefik reaches it over
+    # halos-proxy-network (auto-injected). ILP and the PostgreSQL wire protocol
+    # take any caller with no credential, so they stay on loopback and get no
+    # Traefik router.
+    ports:
+      - "127.0.0.1:9000:9000"
+      - "127.0.0.1:9009:9009"
+      - "127.0.0.1:8812:8812"
+    volumes:
+      - ${CONTAINER_DATA_ROOT}/db:/var/lib/questdb
+    environment:
+      - QDB_TELEMETRY_ENABLED=false
+      - QDB_HTTP_ENABLED=true
+      - QDB_LINE_TCP_ENABLED=true
+      # QuestDB's default commit mode, nosync, fsyncs nothing on the ingest
+      # path and leaves durability to the OS page cache. A power cut can then
+      # land a commit record while the partition data it describes is still
+      # dirty: the table claims rows that are not on disk, and QuestDB fails
+      # while OPENING that partition. No RESUME WAL variant repairs it -- both
+      # remedies run after the open -- so it costs the whole table. With sync,
+      # partition columns are fsynced before the commit record is written and
+      # WAL segments are fsynced on commit, so the stored state can never claim
+      # data it does not have. Writes are already batched by the plugin's
+      # commit interval, so the cost at boat data rates is negligible.
+      - QDB_CAIRO_COMMIT_MODE=sync
+      # Single workers throughout: this runs beside Signal K, InfluxDB, Grafana
+      # and the web stack on a Pi-class board, and QuestDB's defaults size
+      # themselves to the core count.
+      - QDB_CAIRO_WAL_APPLY_WORKER_COUNT=1
+      - QDB_SHARED_WORKER_COUNT=1
+      - QDB_LINE_TCP_WRITER_WORKER_COUNT=1
+      - QDB_CAIRO_O3_COLUMN_MEMORY_SIZE=262144
+    # QuestDB memory-maps every partition column file and every WAL segment, so
+    # it needs far more descriptors than the stock limit grants. The container
+    # inherits this from the runtime rather than from the host's fs.file-max.
+    ulimits:
+      nofile:
+        soft: 1048576
+        hard: 1048576
+    # The JVM sizes its heap from the cgroup limit, so capping here bounds the
+    # total footprint including off-heap rather than just the heap.
+    mem_limit: ${QUESTDB_MEMORY_LIMIT:-768m}
+    cpus: 1.5
+    healthcheck:
+      # /ping is QuestDB's liveness endpoint and answers 204 immediately.
+      # Probing / instead makes curl hang on the console's 301 until timeout.
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:9000/ping"]
+      interval: 30s
+      timeout: 5s
+      start_period: 15s
+      retries: 3

--- a/apps/questdb/icon.svg
+++ b/apps/questdb/icon.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 812 812" fill="none"><g transform="translate(0 55.5)"><path d="M133.387 350.187C133.387 228.785 233.243 130.989 357.202 130.989C401.965 130.989 443.284 143.354 477.717 165.836L574.13 72.5358C514.446 27.572 438.693 0.59375 357.202 0.59375C159.786 0.59375 0.246094 156.843 0.246094 350.187C0.246094 543.531 159.786 699.781 357.202 699.781V569.386C233.243 569.386 133.387 471.589 133.387 350.187Z" fill="url(#paint0_linear)"/>
+<path d="M581.015 350.192H714.156C714.156 258.016 677.428 173.709 617.744 110.76L523.627 202.935C559.208 242.279 581.015 293.987 581.015 350.192Z" fill="url(#paint1_linear)"/>
+<path d="M466.239 361.43H269.971L616.596 700.906L811.717 699.782L466.239 361.43Z" fill="url(#paint2_linear)"/>
+<path opacity="0.6" d="M47.3016 175.957C-38.7809 421.01 218.319 523.302 218.319 523.302C190.772 503.069 156.339 455.857 146.01 422.134C124.202 352.44 131.089 297.359 166.669 236.658" fill="url(#paint3_linear)"/>
+<defs>
+<linearGradient id="paint0_linear" x1="803.686" y1="702.01" x2="178.788" y2="54.7941" gradientUnits="userSpaceOnUse">
+<stop stop-color="#892C6C"/>
+<stop offset="1" stop-color="#D14671"/>
+</linearGradient>
+<linearGradient id="paint1_linear" x1="143.714" y1="42.0442" x2="790.93" y2="692.448" gradientUnits="userSpaceOnUse">
+<stop stop-color="#C34170"/>
+<stop offset="1" stop-color="#8B2C6C"/>
+</linearGradient>
+<linearGradient id="paint2_linear" x1="774.991" y1="686.071" x2="115.023" y2="42.0437" gradientUnits="userSpaceOnUse">
+<stop stop-color="#882B6B"/>
+<stop offset="1" stop-color="#CF4671"/>
+</linearGradient>
+<linearGradient id="paint3_linear" x1="85.9224" y1="476.222" x2="175.953" y2="220.969" gradientUnits="userSpaceOnUse">
+<stop stop-color="white" stop-opacity="0.38"/>
+<stop offset="0.8598" stop-color="white" stop-opacity="0.01"/>
+<stop offset="1" stop-color="white" stop-opacity="0"/>
+</linearGradient>
+</defs></g></svg>

--- a/apps/questdb/metadata.yaml
+++ b/apps/questdb/metadata.yaml
@@ -5,9 +5,12 @@ upstream_version: 10.0.0
 description: Time-series database for high-rate marine data logging
 long_description: |
   QuestDB is a time-series database built for high ingestion rates on modest
-  hardware. It stores Signal K history for the QuestDB history provider plugin,
-  which serves it back to Skip, Freeboard-SK and any other Signal K client
-  through the server's history API.
+  hardware.
+
+  On its own it records nothing. It is the storage backend for the QuestDB
+  history provider plugin in Signal K, which writes vessel data into it and
+  serves it back to Skip, Freeboard-SK and any other Signal K client through
+  the server's history API. Install and configure that plugin to log anything.
 
   Features:
   - Column-oriented storage with daily partitioning and deduplication

--- a/apps/questdb/metadata.yaml
+++ b/apps/questdb/metadata.yaml
@@ -1,0 +1,50 @@
+name: QuestDB
+app_id: questdb
+version: 10.0.0-1
+upstream_version: 10.0.0
+description: Time-series database for high-rate marine data logging
+long_description: |
+  QuestDB is a time-series database built for high ingestion rates on modest
+  hardware. It stores Signal K history for the QuestDB history provider plugin,
+  which serves it back to Skip, Freeboard-SK and any other Signal K client
+  through the server's history API.
+
+  Features:
+  - Column-oriented storage with daily partitioning and deduplication
+  - SQL with time-series extensions, through a web console or PostgreSQL clients
+  - InfluxDB line protocol ingestion
+  - PostgreSQL wire protocol, so Grafana reads it with its standard datasource
+  - Parquet and CSV export
+homepage: https://questdb.com/
+maintainer: Matti Airas <matti.airas@hatlabs.fi>
+license: Apache-2.0
+tags:
+  - role::container-app
+  - field::marine
+  - category::monitoring
+  - interface::web
+  - use::organizing
+  - works-with::logfile
+debian_section: net
+architecture: all
+depends:
+  - docker.io (>= 20.10) | docker-ce (>= 20.10)
+web_ui:
+  enabled: true
+  path: /
+  port: 9000
+  protocol: http
+  visible: true
+routing:
+  port: 9000
+  auth:
+    # QuestDB's open-source build has no authentication and no SQL permission
+    # model, so the console is an unrestricted client that can drop tables.
+    # Traefik carries the whole gate; mode: none would publish it outright.
+    mode: forward_auth
+layout:
+  priority: 50
+  width: 2
+  height: 2
+default_config:
+  QUESTDB_MEMORY_LIMIT: 768m

--- a/apps/questdb/prestart.sh
+++ b/apps/questdb/prestart.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# QuestDB app-prestart hook (sourced by the generated framework prestart).
+#
+# QuestDB memory-maps every partition column file and every WAL segment, so a
+# grown database exhausts the stock vm.max_map_count of 65530. mmap then fails
+# while plenty of RAM is free: queries error and WAL apply suspends, which reads
+# as "recording stopped" with nothing in the logs about memory. The limit is
+# kernel-global rather than per-namespace, so neither a container sysctl flag
+# nor anything inside the container reaches it -- it has to be set on the host.
+#
+# The framework prestart runs as ExecStartPre under `set -e`, so a non-zero
+# status here keeps the container down and eventually latches the unit in
+# `failed`. A host that will not take the sysctl should still get a running
+# QuestDB, so errexit is off for the hook and every problem warns and carries on.
+set +e
+
+RECOMMENDED_MAX_MAP_COUNT=1048576
+SYSCTL_FILE="/etc/sysctl.d/99-questdb.conf"
+SYSCTL_PATH="/proc/sys/vm/max_map_count"
+
+questdb_warn() {
+    echo "WARNING: $*" >&2
+}
+
+current=$(cat "${SYSCTL_PATH}" 2>/dev/null)
+if [ -z "${current}" ]; then
+    questdb_warn "could not read vm.max_map_count; leaving ${SYSCTL_FILE} untouched"
+    exit 0
+fi
+
+# The drop-in is what survives a reboot; the live value is what this boot uses.
+# Both are checked because either can be missing on its own: a fresh install has
+# neither, and an install whose drop-in was written before a kernel parameter
+# override still boots with the old value.
+if [ ! -f "${SYSCTL_FILE}" ]; then
+    if ! printf 'vm.max_map_count=%s\n' "${RECOMMENDED_MAX_MAP_COUNT}" > "${SYSCTL_FILE}"; then
+        questdb_warn "could not write ${SYSCTL_FILE}; QuestDB may exhaust its memory mappings once the database grows"
+        exit 0
+    fi
+    echo "Wrote ${SYSCTL_FILE} (vm.max_map_count=${RECOMMENDED_MAX_MAP_COUNT})"
+fi
+
+if [ "${current}" -lt "${RECOMMENDED_MAX_MAP_COUNT}" ]; then
+    if sysctl -q -w "vm.max_map_count=${RECOMMENDED_MAX_MAP_COUNT}"; then
+        echo "Raised vm.max_map_count from ${current} to ${RECOMMENDED_MAX_MAP_COUNT}"
+    else
+        questdb_warn "vm.max_map_count is ${current}, below the ${RECOMMENDED_MAX_MAP_COUNT} QuestDB needs, and could not be raised; a grown database will fail queries and suspend recording"
+    fi
+fi
+
+exit 0

--- a/run
+++ b/run
@@ -37,6 +37,13 @@ function lint {
   local failed=0
   local checked=0
 
+  # Compose interpolates before it validates, and several apps carry runtime
+  # values the unit supplies (${HALOS_DOMAIN} in extra_hosts, for one). Unset,
+  # those become empty strings that fail schema checks, so lint would report a
+  # valid file as broken. Placeholders keep the check on the file's own shape.
+  export HALOS_DOMAIN=lint.invalid
+  export CONTAINER_DATA_ROOT=/nonexistent/lint
+
   for compose_file in apps/*/docker-compose.yml; do
     if [ -f "$compose_file" ]; then
       checked=$((checked + 1))
@@ -45,7 +52,10 @@ function lint {
         echo "  ✅ $app_name"
       else
         echo "  ❌ $app_name"
-        docker compose -f "$compose_file" config 2>&1 | sed 's/^/     /'
+        # `|| true`: errexit plus pipefail would otherwise abort the whole run
+        # here, so the first bad file hid every file after it and the summary
+        # below never printed.
+        docker compose -f "$compose_file" config 2>&1 | sed 's/^/     /' || true
         failed=$((failed + 1))
       fi
     fi

--- a/tests/test_questdb_app.py
+++ b/tests/test_questdb_app.py
@@ -38,21 +38,20 @@ def _environment() -> dict[str, str]:
     return dict(item.split("=", 1) for item in env)
 
 
-def test_ingest_and_sql_ports_are_loopback_only():
-    """ILP and the PostgreSQL wire protocol reach the database with no auth.
+def test_every_published_port_is_loopback_only():
+    """No port of QuestDB's authenticates anything, on any protocol.
 
-    Publishing either on a wildcard address hands the vessel's history to
-    anything on the boat network, with no credential in the way.
+    Publishing any of them on a wildcard address hands the vessel's history to
+    the whole boat network with no credential in the way. This covers the
+    device's own interfaces only -- containers on halos-proxy-network reach
+    every container port regardless of what is published here.
     """
-    unauthenticated = {"9009", "8812"}
-
     for mapping in _service()["ports"]:
         host_ip, host_port, _container_port = mapping.split(":")
-        if host_port in unauthenticated:
-            assert host_ip == "127.0.0.1", (
-                f"port {host_port} is published on {host_ip}; QuestDB does not "
-                "authenticate it, so it must stay on loopback"
-            )
+        assert host_ip == "127.0.0.1", (
+            f"port {host_port} is published on {host_ip}; QuestDB authenticates "
+            "nothing, so no port may leave the host's loopback interface"
+        )
 
 
 def test_commit_mode_is_sync():
@@ -80,13 +79,14 @@ def test_prestart_raises_max_map_count():
     assert str(RECOMMENDED_MAX_MAP_COUNT) in prestart
 
 
-def test_console_is_not_routed_without_authentication():
+def test_console_is_gated_by_forward_auth():
     """The console is a full SQL client and can drop tables.
 
-    Exposing it through Traefik with auth mode "none" -- as InfluxDB does,
-    because InfluxDB authenticates its own UI -- would publish it to anyone who
-    reaches the device.
+    Authelia is the whole gate: QuestDB has no login of its own, so nothing
+    below forward_auth protects it. Mode "none" -- which InfluxDB can afford,
+    because InfluxDB authenticates its own UI -- would publish it outright, and
+    "oidc" would claim a native OAuth integration QuestDB does not have.
     """
     auth_mode = _metadata()["routing"]["auth"]["mode"]
 
-    assert auth_mode != "none"
+    assert auth_mode == "forward_auth"

--- a/tests/test_questdb_app.py
+++ b/tests/test_questdb_app.py
@@ -1,0 +1,92 @@
+"""Tests for the QuestDB container app definition.
+
+QuestDB's open-source build authenticates nothing: the HTTP console is an
+unrestricted SQL client and the ILP and PostgreSQL ports take any caller. What
+keeps that safe here is the app definition itself, and every property below
+fails silently if it regresses -- the container still starts, still records, and
+still answers queries.
+"""
+
+from pathlib import Path
+
+import yaml
+
+APP_DIR = Path(__file__).parent.parent / "apps" / "questdb"
+
+# QuestDB memory-maps every partition column file and every WAL segment.
+RECOMMENDED_MAX_MAP_COUNT = 1048576
+
+
+def _compose() -> dict:
+    with open(APP_DIR / "docker-compose.yml") as f:
+        return yaml.safe_load(f)
+
+
+def _metadata() -> dict:
+    with open(APP_DIR / "metadata.yaml") as f:
+        return yaml.safe_load(f)
+
+
+def _service() -> dict:
+    services = _compose()["services"]
+    assert len(services) == 1, "one service, so the port assertions below cover it"
+    return next(iter(services.values()))
+
+
+def _environment() -> dict[str, str]:
+    env = _service().get("environment", [])
+    return dict(item.split("=", 1) for item in env)
+
+
+def test_ingest_and_sql_ports_are_loopback_only():
+    """ILP and the PostgreSQL wire protocol reach the database with no auth.
+
+    Publishing either on a wildcard address hands the vessel's history to
+    anything on the boat network, with no credential in the way.
+    """
+    unauthenticated = {"9009", "8812"}
+
+    for mapping in _service()["ports"]:
+        host_ip, host_port, _container_port = mapping.split(":")
+        if host_port in unauthenticated:
+            assert host_ip == "127.0.0.1", (
+                f"port {host_port} is published on {host_ip}; QuestDB does not "
+                "authenticate it, so it must stay on loopback"
+            )
+
+
+def test_commit_mode_is_sync():
+    """QuestDB's default leaves durability to the OS page cache.
+
+    A power cut can then land a commit record while the partition data it
+    describes is still dirty. The table claims rows that are not on disk and
+    QuestDB fails while opening the partition -- a state no RESUME WAL variant
+    repairs, because the failure happens before any transaction is read. Boats
+    lose power; this is the deployment, not an edge case.
+    """
+    assert _environment().get("QDB_CAIRO_COMMIT_MODE") == "sync"
+
+
+def test_prestart_raises_max_map_count():
+    """The stock limit of 65530 exhausts on a grown database.
+
+    mmap then fails while RAM is still free: queries error and WAL apply
+    suspends. The limit is kernel-global rather than per-namespace, so no
+    container flag reaches it and the host has to be configured.
+    """
+    prestart = (APP_DIR / "prestart.sh").read_text()
+
+    assert "vm.max_map_count" in prestart
+    assert str(RECOMMENDED_MAX_MAP_COUNT) in prestart
+
+
+def test_console_is_not_routed_without_authentication():
+    """The console is a full SQL client and can drop tables.
+
+    Exposing it through Traefik with auth mode "none" -- as InfluxDB does,
+    because InfluxDB authenticates its own UI -- would publish it to anyone who
+    reaches the device.
+    """
+    auth_mode = _metadata()["routing"]["auth"]["mode"]
+
+    assert auth_mode != "none"


### PR DESCRIPTION
First phase of [issue 236](https://github.com/halos-org/halos-marine-containers/issues/236). It adds the database only — the Signal K history provider that writes to it, and the wiring that points Signal K at it, come in later PRs. The app is deliberately not reachable from the marine metapackage yet, so nothing installs a database with no writer.

The app comes before the plugin so the plugin has a verified target to point at: a failure in the history path then has one new half rather than two.

## Approach

QuestDB is packaged like InfluxDB, with three differences that are all about what QuestDB does not do for itself.

**It authenticates nothing.** The open-source build has no credentials and no SQL permission model, on any of its three ports. All three are published on host loopback only, and only the HTTP port gets a Traefik router, behind Authelia forward auth — hence `routing.auth.mode: forward_auth` rather than the `none` InfluxDB can afford by authenticating its own UI.

That bounds the host's interfaces and nothing else, which the first draft of this description got wrong. The generator joins every non-host-networked app to `halos-proxy-network` (`routing.py:88`), that network is a plain bridge, and Docker port publication does not gate container-to-container traffic — so **any app container on the box reaches all three QuestDB ports directly**, with neither Traefik nor Authelia in the path. Every other app on that network authenticates its own callers; QuestDB is the first datastore there with nothing to fall back on. Raised by CodeRabbit, and left as-is here deliberately: closing it means either an isolated backend network shared only with Traefik and QuestDB, or a policy that app containers are not mutually trusted. Both are architecture decisions wider than this app.

**Its default commit mode can cost a table.** QuestDB fsyncs nothing on the ingest path by default and leaves durability to the page cache. A power cut can land a commit record while the partition data it describes is still dirty; the table then claims rows that are not on disk and QuestDB fails while *opening* the partition — before any transaction is read, so no `RESUME WAL` variant reaches it. `cairo.commit.mode=sync` makes that state unrepresentable. Boats lose power, so this is the deployment rather than an edge case.

**One limit it needs is not settable from a container.** QuestDB memory-maps every partition column file and every WAL segment, and the stock `vm.max_map_count` of 65530 exhausts on a grown database — mmap then fails while RAM is free, which surfaces as failed queries and suspended recording rather than as anything mentioning memory. The limit is kernel-global rather than per-namespace, so no container sysctl reaches it and the prestart writes a host drop-in.

The container environment otherwise mirrors what the history-provider plugin sets when it manages QuestDB itself: single workers throughout and a small O3 column buffer, because this runs beside Signal K, InfluxDB, Grafana and the web stack on a Pi-class board.

## Tests

`tests/test_questdb_app.py` covers the four properties that fail silently — the container still starts, still records, still answers queries — if they regress: the unauthenticated ports staying on loopback, sync commit mode, the sysctl drop-in, and the console not being routed without authentication.

## Fly-by fix

`./run lint` was aborting on the first failing compose file, so four of six apps were never checked, and it reported valid files as broken because Compose interpolates before it validates and the runtime variables the units supply were unset. Both are fixed in a separate commit. Lint now passes on all six.

## Verification

- `./run lint` — all 6 valid
- `python3 -m pytest tests/` — 44 passed, plus one pre-existing failure in `test_signalk_prestart.py` that reproduces identically on `main` (the harness expects Linux `*at` semantics and fails on macOS; it is green in CI)
- `./run build` — `marine-questdb-container_10.0.0-1_all.deb` builds, and its generated routing, Homarr entry and control metadata were inspected
- `generate-container-packages --validate` — passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added QuestDB as a ready-to-use application for time-series data storage.
  - Includes a web console, HTTP and line-protocol ingestion, PostgreSQL connectivity, and persistent data storage.
  - Services are protected by loopback-only exposure and authenticated web access.
  - Added health monitoring, telemetry opt-out, synchronous commits, and configurable memory limits.
  - Startup now applies recommended system settings automatically when possible.

- **Chores**
  - Improved configuration validation and reporting across application definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->