### PR TITLE
Configure the QuestDB history provider in Signal K

### DIFF
--- a/apps/signalk-server/docker-compose.yml
+++ b/apps/signalk-server/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     # halos-org/signalk-server-docker. Exact tag, never a floating one: the tag
     # names an artifact that passed that repo's verification, and nothing in the
     # curated set is version-pinned, so a re-resolved rebuild is a different image.
-    image: ghcr.io/halos-org/signalk-server-docker:v2.30.0-halos.2
+    image: ghcr.io/halos-org/signalk-server-docker:v2.30.0-halos.4
     container_name: signalk-server
     init: true
     restart: unless-stopped

--- a/apps/signalk-server/metadata.yaml
+++ b/apps/signalk-server/metadata.yaml
@@ -1,6 +1,6 @@
 name: Signal K Server
 app_id: signalk-server
-version: 2.30.0-8
+version: 2.30.0-9
 upstream_version: 2.30.0
 description: Signal K server for marine data processing and routing
 long_description: |

--- a/apps/signalk-server/prestart.sh
+++ b/apps/signalk-server/prestart.sh
@@ -49,15 +49,23 @@ if [ -f "${INFLUXDB_ENV}" ]; then
     INFLUXDB_ADMIN_TOKEN=$(grep '^INFLUXDB_ADMIN_TOKEN=' "${INFLUXDB_ENV}" | cut -d= -f2-)
 fi
 
+QUESTDB_ENV="${QUESTDB_ENV:-/etc/container-apps/marine-questdb-container/env}"
+QUESTDB_INSTALLED=""
+if [ -f "${QUESTDB_ENV}" ]; then
+    QUESTDB_INSTALLED=1
+fi
+
 HALOS_DATA_ROOT="${CONTAINER_DATA_ROOT}" \
 HALOS_SK_DATA="${SIGNALK_DATA}" \
 HALOS_INFLUX_TOKEN="${INFLUXDB_ADMIN_TOKEN}" \
+HALOS_QUESTDB_INSTALLED="${QUESTDB_INSTALLED}" \
 python3 -P - <<'HALOS_SECRETS_PY'
 import errno, json, os, secrets, stat, sys
 
 DATA_ROOT = os.environ["HALOS_DATA_ROOT"]
 SK_DATA = os.environ["HALOS_SK_DATA"]
 INFLUX_TOKEN = os.environ.get("HALOS_INFLUX_TOKEN") or ""
+QUESTDB_INSTALLED = bool(os.environ.get("HALOS_QUESTDB_INSTALLED"))
 
 # A racer that wins once will usually lose the next attempt; one that wins every
 # attempt is not a race we can outlast, and refusing to start is then correct.
@@ -233,17 +241,81 @@ def converge_mode(dfd, name):
         os.close(fd)
 
 
-def configure_influx(sk_fd, token):
-    """Point the logging plugin at InfluxDB. Never fatal; see the call site."""
+def open_plugin_config_dir(sk_fd):
+    """Descriptor for plugin-config-data, or None when it cannot be made safe.
+
+    Both plugin configs land here, in a directory uid 1000 owns, so the type
+    check and the mkdir live in one place. Two copies of this could drift, and
+    the half that drifted would write a config through whatever was planted at
+    that name.
+    """
     if not clear_unexpected(sk_fd, "plugin-config-data", want_dir=True):
         warn("cannot make plugin-config-data safe to write; skipping")
-        return
+        return None
     try:
         os.mkdir("plugin-config-data", 0o755, dir_fd=sk_fd)
     except FileExistsError:
         pass
+    return open_dir("plugin-config-data", parent_fd=sk_fd)
 
-    cfg_fd = open_dir("plugin-config-data", parent_fd=sk_fd)
+
+def configure_questdb(sk_fd):
+    """Point the history provider at the QuestDB app. Never fatal.
+
+    Written once and then left alone, unlike the InfluxDB config below. That one
+    is rewritten every boot because a rotating token has to reach it; this one
+    carries no secret, so a rewrite could only ever discard what the operator
+    changed -- path filters, sampling rates, retention. It would also re-arm the
+    one-off default-provider promotion, taking back a default the operator had
+    since moved somewhere else.
+
+    Host and ports are written explicitly even though they are the plugin's
+    defaults. A rebase onto a new upstream may move those defaults, and a
+    device's configuration should not follow silently.
+    """
+    cfg_fd = open_plugin_config_dir(sk_fd)
+    if cfg_fd is None:
+        return
+    try:
+        name = "signalk-questdb-history-provider.json"
+        if not clear_unexpected(cfg_fd, name):
+            warn("cannot make %s safe to write; skipping" % name)
+            return
+
+        converge_mode(cfg_fd, name)
+        try:
+            fd = open_regular(cfg_fd, name)
+        except FileNotFoundError:
+            pass
+        else:
+            os.close(fd)
+            return
+
+        if create_guarded(cfg_fd, name, json.dumps({
+            "enabled": True,
+            "configuration": {
+                "managedContainer": False,
+                "questdbHost": "127.0.0.1",
+                "questdbHttpPort": 9000,
+                "questdbIlpPort": 9009,
+                # Claimed once by the plugin, which clears this flag itself the
+                # moment the server confirms. Writing settings.json here instead
+                # would name a provider before it has registered, and Signal K
+                # raises a warn notification for a configured provider that
+                # stays missing.
+                "promoteToDefaultProvider": True,
+            },
+        }, indent=2) + "\n"):
+            print("QuestDB history provider configured")
+    finally:
+        os.close(cfg_fd)
+
+
+def configure_influx(sk_fd, token):
+    """Point the logging plugin at InfluxDB. Never fatal; see the call site."""
+    cfg_fd = open_plugin_config_dir(sk_fd)
+    if cfg_fd is None:
+        return
     try:
         name = "signalk-to-influxdb2.json"
         if not clear_unexpected(cfg_fd, name):
@@ -488,6 +560,12 @@ if INFLUX_TOKEN:
         configure_influx(sk_fd, INFLUX_TOKEN)
     except Exception as exc:
         warn("InfluxDB plugin config not updated: %s" % exc)
+
+if QUESTDB_INSTALLED:
+    try:
+        configure_questdb(sk_fd)
+    except Exception as exc:
+        warn("QuestDB plugin config not written: %s" % exc)
 
 os.close(sk_fd)
 os.close(root_fd)

--- a/tools/test-prestart.sh
+++ b/tools/test-prestart.sh
@@ -164,6 +164,7 @@ run_hook() {  # echoes exit status
         RUNTIME_ENV="${SANDBOX}/runtime.env" \
         HALOS_DOMAIN="test.local" \
         INFLUXDB_ENV="${SANDBOX}/influxdb.env" \
+        QUESTDB_ENV="${SANDBOX}/questdb.env" \
         PYTHONPATH="${SANDBOX}/pylib" \
         ${TIMEOUT:+"${TIMEOUT}" -s KILL 20} \
         bash -c 'set -e; . "$1"' _ "${HOOK}" > "${SANDBOX}/out" 2>&1
@@ -172,6 +173,10 @@ run_hook() {  # echoes exit status
 
 influx_available() {  # $1 = token to publish
     printf 'INFLUXDB_ADMIN_TOKEN=%s\n' "$1" > "${SANDBOX}/influxdb.env"
+}
+
+questdb_available() {  # the app's env file is the only signal; it holds no secret
+    : > "${SANDBOX}/questdb.env"
 }
 
 # Matches the whole call, not just the path. Asserting only that the path was
@@ -253,6 +258,60 @@ check "no influx config without the InfluxDB env file" "$(run_hook)" "0"
 [ ! -e "${SK}/plugin-config-data/signalk-to-influxdb2.json" ] &&
     ok "  config is absent" ||
     bad "  config is absent" "$(cat "${SK}/plugin-config-data/signalk-to-influxdb2.json")"
+teardown
+
+# QuestDB's config is gated on the app being installed, unlike InfluxDB's. There
+# is no token to inject here, so nothing forces an unconditional write -- and a
+# config naming a database that is not there makes the plugin report an error
+# on a device that simply chose not to install it.
+setup
+questdb_available
+check "questdb config is written when the app is installed" "$(run_hook)" "0"
+QDB_CFG="${SK}/plugin-config-data/signalk-questdb-history-provider.json"
+check "  at 0600" "$(mode "${QDB_CFG}")" "600"
+python3 - "${QDB_CFG}" <<'EOF' && ok "  external mode, loopback, promotion armed" ||
+import json, sys
+c = json.load(open(sys.argv[1]))
+cfg = c["configuration"]
+assert c["enabled"] is True, c
+assert cfg["managedContainer"] is False, cfg
+assert cfg["questdbHost"] == "127.0.0.1", cfg
+assert cfg["promoteToDefaultProvider"] is True, cfg
+EOF
+    bad "  external mode, loopback, promotion armed" "$(cat "${QDB_CFG}")"
+teardown
+
+setup
+check "no questdb config without the app installed" "$(run_hook)" "0"
+[ ! -e "${SK}/plugin-config-data/signalk-questdb-history-provider.json" ] &&
+    ok "  config is absent" ||
+    bad "  config is absent" "$(cat "${SK}/plugin-config-data/signalk-questdb-history-provider.json")"
+teardown
+
+# Write once, never rewrite. InfluxDB's config is rewritten every boot because a
+# rotating token has to reach it; this one carries no secret, so rewriting would
+# only ever discard what the operator changed -- path filters, sampling rates,
+# retention -- on the next restart. It would also re-arm the one-off promotion,
+# taking back a default the operator had since moved elsewhere.
+setup
+questdb_available
+run_hook > /dev/null
+QDB_CFG="${SK}/plugin-config-data/signalk-questdb-history-provider.json"
+python3 - "${QDB_CFG}" <<'EOF'
+import json, sys
+c = json.load(open(sys.argv[1]))
+c["configuration"]["retentionDays"] = 30
+c["configuration"]["promoteToDefaultProvider"] = False
+json.dump(c, open(sys.argv[1], "w"))
+EOF
+check "an edited questdb config survives the next boot" "$(run_hook)" "0"
+python3 - "${QDB_CFG}" <<'EOF' && ok "  operator edits are intact" ||
+import json, sys
+cfg = json.load(open(sys.argv[1]))["configuration"]
+assert cfg["retentionDays"] == 30, cfg
+assert cfg["promoteToDefaultProvider"] is False, cfg
+EOF
+    bad "  operator edits are intact" "$(cat "${QDB_CFG}")"
 teardown
 
 # signalk-halpi's postinst creates both paths as root before Signal K has ever


### PR DESCRIPTION
Completes Phase 3 of [issue 236](https://github.com/halos-org/halos-marine-containers/issues/236). Repins the Signal K image at `v2.30.0-halos.4` — which carries `signalk-questdb-history-provider`, added in [signalk-server-docker#29](https://github.com/halos-org/signalk-server-docker/pull/29) — and writes the plugin's configuration from the prestart.

After this, a device with the QuestDB app installed records to QuestDB and serves history from it. InfluxDB keeps recording and keeps answering under its own provider id; nothing already on a device becomes unreadable.

## Three decisions worth reviewing

**Written once, then left alone.** The InfluxDB config beside it is rewritten every boot because a rotating token has to reach it. This one carries no secret, so a rewrite could only ever discard what the operator changed — path filters, sampling rates, retention — on the next restart. It would also re-arm the one-off default-provider promotion, taking back a default they had since moved elsewhere. That is the same sticky-configuration bug the fork just removed from the plugin; recreating it here would have been silent.

**The promotion is the plugin's to perform, not this hook's.** The obvious alternative was writing `historyApi.defaultProvider` into `settings.json` directly. That names a provider before it has registered, and Signal K arms a grace timer and then raises a `warn` at `notifications.server.history.defaultProvider` for a configured provider that stays missing — a standing warning on any device where QuestDB is slow or absent. Instead the config sets `promoteToDefaultProvider`, and the plugin claims the slot only once it is actually running, then clears the flag itself. It also avoids adding a second root writer to `settings.json`, which the gpsd-liner migration already writes.

**Gated on the app being installed**, unlike the InfluxDB block. That one writes unconditionally because it cannot detect a plugin baked into the image and has a token that must arrive. Here there is nothing to force, and a config naming a database that is not there makes the plugin report an error on a device that simply chose not to install QuestDB. The cost is latency: installing the app later does not restart Signal K, so the config appears at the next restart.

Host and ports are written explicitly even though they are the plugin's defaults. A rebase onto a new upstream can move those defaults, and a device's configuration should not follow silently.

## Shared directory handling

`configure_influx` and `configure_questdb` both write into a directory uid 1000 owns, so the type check and mkdir moved into `open_plugin_config_dir`. Two copies could drift, and the half that drifted would write a config through whatever was planted at that name — the exact failure the descriptor-relative machinery in this file exists to prevent.

## Tests

Three scenarios in `tools/test-prestart.sh`, following the existing shape:

- the app installed writes the config, at 0600, in external mode on loopback with promotion armed
- the app absent writes nothing
- an operator-edited config survives the next boot with its edits intact, including a `promoteToDefaultProvider` they turned back off

That last one is the guard against reintroducing the rewrite-every-boot behaviour.

## Verification

- `bash tools/test-prestart.sh` — 133 passed, up from 126, with all three new scenarios green
- `python3 -m pytest tests/ -k "not test_prestart_hook_behaves"` — 40 passed, including `test_image_is_the_baked_one_at_an_exact_tag` and `test_image_exists_in_the_registry`, so the repin is checked against GHCR rather than being a string edit
- The 14 failures inside `test_prestart_hook_behaves` are pre-existing and reproduce identically on `main` from a clean worktree: the harness asserts Linux `*at` semantics and fails on macOS. It is green in CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic QuestDB history-provider configuration when QuestDB is installed.
  * Preserved operator-configured QuestDB settings across subsequent starts.

* **Bug Fixes**
  * Improved startup handling for missing configuration files and directories.
  * Prevented QuestDB setup issues from blocking application startup.
  * Updated the bundled Signal K Server image and package versions.

* **Tests**
  * Added coverage for QuestDB setup, permissions, default connection settings, and configuration persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->