### PR TITLE
Set the default history provider in settings.json

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -304,13 +304,19 @@ Three of the hook's jobs look like leftovers and are not:
   into a container exposes them; `package.json` only because nothing writes it,
   so adding a write does.
 
-  `settings.json` was in that list until the gpsd liner migration below gave it a
-  writer, and it is the case to read before adding another one. The file holds
-  nothing secret, so what makes it dangerous is only that root writes into a
-  directory uid 1000 owns — the same property, arrived at without a secret to
-  point to. It goes through the same descriptor-relative `O_EXCL` create and
-  `renameat` as everything else here, and the temp and backup names it writes are
-  covered by those creates rather than by a guard that lists them.
+  `settings.json` was in that list until it acquired writers, and it is the case
+  to read before adding another one. The file holds nothing secret, so what makes
+  it dangerous is only that root writes into a directory uid 1000 owns — the same
+  property, arrived at without a secret to point to. It goes through the same
+  descriptor-relative `O_EXCL` create and `renameat` as everything else here, and
+  the temp and backup names it writes are covered by those creates rather than by
+  a guard that lists them.
+
+  Both writers share `read_settings` and `write_settings` rather than each
+  carrying a copy. The read has three ways to corrupt a value it was not asked to
+  touch — dropping the mode uid 1000 chose, decoding in the process locale
+  instead of UTF-8, accepting a document that is not an object — and a second
+  copy only has to drift on one of them.
 
 - **`node_modules` and `package.json` are handed to uid 1000 on every start.**
   `signalk-halpi`'s postinst creates both as root when it registers itself as a
@@ -397,6 +403,45 @@ actually recreates the container.
 date the migration is a root write into a container-owned directory that can no
 longer find anything to repair — open an issue to take it out rather than
 renewing it by default.
+
+### The default history provider
+
+`settings.json`'s `historyApi.defaultProvider` is the only place the server takes
+this from. The prestart writes it when the QuestDB app is installed and the key
+is absent, and removes it when the app is gone and the key still names QuestDB.
+Every other value is the operator's and is never touched.
+
+**The plugin cannot set it, and trying looks like it works.** Signal K's route
+for it, `POST /signalk/v2/api/history/_providers/_default/:id`, is covered by
+`writeAuthenticationMiddleware` on `POST /signalk/v2/*`, which wants `admin` or
+`readwrite`. A plugin runs inside the server but reaches that route as an
+ordinary loopback client with no credentials, so it gets 401 on every boot of a
+device with security enabled — which is every HaLOS device. The plugin did
+exactly this until the fix, logging one 401 per boot forever while nothing
+downstream noticed.
+
+**Doing nothing is not neutral.** With no configured default, the server serves
+history from whichever provider registered first, which is plugin load order.
+`signalk-to-influxdb2` is baked into the same image, so on a device with both apps
+it wins — confirmed on hardware: `_providers` reported InfluxDB `isDefault: true`
+and QuestDB `false`, which is the opposite of what the QuestDB app is for.
+
+**A key naming a gone provider is a standing alarm, not a fallback.** This was
+first written the other way, from a device test that never exercised the path.
+The warn is raised by `warnIfConfiguredUnavailable()`, which `useProvider()`
+calls — so a *history request* triggers it, not a timer, and probing the
+notification tree before issuing one shows nothing. Issue one and
+`notifications.server.history.defaultProvider` reports `state: "warn"`,
+"Configured default history provider ... is not available, using ... instead".
+`warnedUnavailable` latches, and only `notifyConfiguredAvailable()` clears it —
+when the provider registers, which for an uninstalled app is never. Hence the
+removal branch. It matches the exact value only, so an operator who chose
+InfluxDB keeps it whether or not QuestDB is installed.
+
+**It needs 2.31.0 or newer.** Persistence landed in that release (`feat: persist
+default History API provider, selectable in Admin UI`). On 2.30.0 the key is read
+by nothing and the write is inert — the failure is silent in both directions, so
+a downgrade of the pinned image below 2.31.0 takes this feature with it.
 
 ### Signal K Plugin Set
 

--- a/apps/signalk-server/metadata.yaml
+++ b/apps/signalk-server/metadata.yaml
@@ -1,6 +1,6 @@
 name: Signal K Server
 app_id: signalk-server
-version: 2.31.1-1
+version: 2.31.1-2
 upstream_version: 2.31.1
 description: Signal K server for marine data processing and routing
 long_description: |

--- a/apps/signalk-server/prestart.sh
+++ b/apps/signalk-server/prestart.sh
@@ -49,9 +49,16 @@ if [ -f "${INFLUXDB_ENV}" ]; then
     INFLUXDB_ADMIN_TOKEN=$(grep '^INFLUXDB_ADMIN_TOKEN=' "${INFLUXDB_ENV}" | cut -d= -f2-)
 fi
 
-QUESTDB_ENV="${QUESTDB_ENV:-/etc/container-apps/marine-questdb-container/env}"
+# The compose file, not the env file. `apt remove` leaves a package in
+# `deinstall ok config-files`: /etc/container-apps/marine-questdb-container/env
+# and the systemd unit both survive, and only `apt purge` takes them. The
+# compose file is payload and goes on either. Gating on env made "the app is
+# gone" false for the ordinary uninstall, which left settings.json naming a
+# provider that can never register -- and that is a standing warn notification,
+# not a quiet fallback. Verified on a device.
+QUESTDB_COMPOSE="${QUESTDB_COMPOSE:-/var/lib/container-apps/marine-questdb-container/docker-compose.yml}"
 QUESTDB_INSTALLED=""
-if [ -f "${QUESTDB_ENV}" ]; then
+if [ -f "${QUESTDB_COMPOSE}" ]; then
     QUESTDB_INSTALLED=1
 fi
 
@@ -70,6 +77,10 @@ QUESTDB_INSTALLED = bool(os.environ.get("HALOS_QUESTDB_INSTALLED"))
 # A racer that wins once will usually lose the next attempt; one that wins every
 # attempt is not a race we can outlast, and refusing to start is then correct.
 ATTEMPTS = 4
+
+# Declared in the plugin's own code, not derived from its package name, and it is
+# the key the history provider registry and settings.json both index by.
+QUESTDB_PLUGIN_ID = "signalk-questdb-history-provider"
 
 
 def warn(msg):
@@ -168,7 +179,7 @@ def create_exclusive(dfd, name, content, mode=0o600):
 
     The default is the secret-file mode. It is a parameter because settings.json
     holds no secret and is read and written by the container: tightening it to
-    0600 as a side effect of repairing it would be a second, silent change.
+    0600 as a side effect of rewriting it would be a second, silent change.
     """
     fd = os.open(
         name,
@@ -241,6 +252,51 @@ def converge_mode(dfd, name):
         os.close(fd)
 
 
+def read_settings(sk_fd):
+    """Parse settings.json into (settings, mode, original), None when absent.
+
+    Two writers below need the same three things, and each of them is a way to
+    corrupt a value neither writer was asked to touch. The mode is the permission
+    bits uid 1000 chose, kept because root recreates the file. UTF-8 is explicit
+    because settings.json is UTF-8 by specification while text mode would decode
+    it in the process locale -- under a single-byte locale a vessel name comes
+    back as two characters that json.dumps then re-escapes. The original text is
+    what the migration keeps as its backup.
+    """
+    try:
+        fd = open_regular(sk_fd, "settings.json")
+    except FileNotFoundError:
+        return None  # a fresh install has none until the postinst seeds default-data
+
+    with os.fdopen(fd, encoding="utf-8") as f:  # owns fd from here
+        # Permission bits only. S_IMODE keeps setuid and setgid as well -- root
+        # would otherwise reproduce them on a file it creates here.
+        mode = stat.S_IMODE(os.fstat(f.fileno()).st_mode) & 0o777
+        original = f.read()
+
+    settings = json.loads(original)
+    if not isinstance(settings, dict):
+        raise ValueError(
+            "settings.json is a %s, not an object" % type(settings).__name__
+        )
+    return settings, mode, original
+
+
+def write_settings(sk_fd, settings, mode):
+    """Replace settings.json atomically. False when the staged write failed."""
+    # Not settings.json.tmp: that is the name the server's own atomic write stages
+    # through, so a leftover there is a root-owned file in its way and its next
+    # save fails EACCES.
+    tmp = "settings.json.halos-tmp"
+    body = json.dumps(settings, indent=2) + "\n"
+    if not create_guarded(sk_fd, tmp, body, replace=True, mode=mode):
+        return False
+    # renameat replaces the name and never follows it, so a symlink swapped in
+    # after the read above is overwritten rather than written through.
+    os.replace(tmp, "settings.json", src_dir_fd=sk_fd, dst_dir_fd=sk_fd)
+    return True
+
+
 def open_plugin_config_dir(sk_fd):
     """Descriptor for plugin-config-data, or None when it cannot be made safe.
 
@@ -265,9 +321,7 @@ def configure_questdb(sk_fd):
     Written once and then left alone, unlike the InfluxDB config below. That one
     is rewritten every boot because a rotating token has to reach it; this one
     carries no secret, so a rewrite could only ever discard what the operator
-    changed -- path filters, sampling rates, retention. It would also re-arm the
-    one-off default-provider promotion, taking back a default the operator had
-    since moved somewhere else.
+    changed -- path filters, sampling rates, retention.
 
     Host and ports are written explicitly even though they are the plugin's
     defaults. A rebase onto a new upstream may move those defaults, and a
@@ -277,7 +331,7 @@ def configure_questdb(sk_fd):
     if cfg_fd is None:
         return
     try:
-        name = "signalk-questdb-history-provider.json"
+        name = QUESTDB_PLUGIN_ID + ".json"
         if not clear_unexpected(cfg_fd, name):
             warn("cannot make %s safe to write; skipping" % name)
             return
@@ -298,17 +352,78 @@ def configure_questdb(sk_fd):
                 "questdbHost": "127.0.0.1",
                 "questdbHttpPort": 9000,
                 "questdbIlpPort": 9009,
-                # Claimed once by the plugin, which clears this flag itself the
-                # moment the server confirms. Writing settings.json here instead
-                # would name a provider before it has registered, and Signal K
-                # raises a warn notification for a configured provider that
-                # stays missing.
-                "promoteToDefaultProvider": True,
             },
         }, indent=2) + "\n"):
             print("QuestDB history provider configured")
     finally:
         os.close(cfg_fd)
+
+
+def set_default_history_provider(sk_fd, installed):
+    """Keep settings.json's default history provider in step with the app.
+
+    When settings name no default, Signal K serves history from whichever
+    provider registered first. signalk-to-influxdb2 is baked into the same image,
+    so that is decided by plugin load order -- and InfluxDB wins it on a device
+    with both installed, which is the configuration we ship.
+
+    settings.json is the only place the server takes this from. The plugin cannot
+    set it: POST /signalk/v2/* wants write-level credentials, and a plugin
+    calling its own server over loopback carries none, so it gets 401 on every
+    boot of a device with security enabled -- which is every HaLOS device.
+
+    Two directions, both narrow:
+
+    * The app is installed and no default is named -- name QuestDB. Only when
+      the key is absent, so an operator who moves the default to InfluxDB
+      keeps it.
+    * The app is gone and the key still names QuestDB -- drop the key. Left
+      behind it costs a standing alarm: the first history request after that
+      raises a warn notification at notifications.server.history.defaultProvider
+      ("Configured default history provider ... is not available"), and the
+      server clears it only when that provider registers again, which for an
+      uninstalled app is never. Verified on a device.
+
+    Any other value is the operator's and is never touched, including the empty
+    string -- that is how the server reads "no default, use the fallback".
+    """
+    read = read_settings(sk_fd)
+    if read is None:
+        return
+    settings, mode, _ = read
+
+    history = settings.get("historyApi")
+    if history is None:
+        history = {}
+    elif not isinstance(history, dict):
+        # Malformed, and root is not the process to decide what it meant.
+        warn("historyApi is a %s, not an object; leaving it alone"
+             % type(history).__name__)
+        return
+
+    # Key presence, not truthiness, on the write side: an empty value is a
+    # choice, and taking it back on every boot is the sticky rewrite this whole
+    # approach exists to avoid.
+    present = "defaultProvider" in history
+    if installed:
+        if present:
+            return
+        history["defaultProvider"] = QUESTDB_PLUGIN_ID
+        message = "QuestDB set as the default history provider"
+    else:
+        # Exact match only. An operator who chose InfluxDB keeps it whether or
+        # not QuestDB is installed; the only value this may remove is the one
+        # this hook wrote.
+        if history.get("defaultProvider") != QUESTDB_PLUGIN_ID:
+            return
+        del history["defaultProvider"]
+        message = "QuestDB is gone; cleared it as the default history provider"
+
+    settings["historyApi"] = history
+    if write_settings(sk_fd, settings, mode):
+        print(message)
+    else:
+        warn("could not update the default history provider")
 
 
 def configure_influx(sk_fd, token):
@@ -372,16 +487,17 @@ def configure_influx(sk_fd, token):
 # container-owned directory bought for nothing. What goes with it:
 #
 #   * migrate_gpsd_liner and its call site
-#   * the `mode` parameter on create_exclusive and create_guarded, and the
-#     paragraph of create_exclusive's docstring that justifies it -- this is the
-#     only caller that passes anything but the default
 #   * the settings.json.pre-liner hand_over below (the settings.json one above it
 #     predates this and stays -- the postinst creates that file root-owned)
 #   * in tools/test-prestart.sh: the "the gpsd liner migration" scenarios, the
 #     element_types helper and the PRE_LINER_SETTINGS fixture
-#   * the settings.json paragraphs in AGENTS.md
+#   * the gpsd paragraphs in AGENTS.md
 #
-# After which settings.json goes back to being a path this hook never writes.
+# What does NOT go with it: read_settings, write_settings, the `mode` parameter
+# they need on create_exclusive and create_guarded, and the settings.json
+# hand_over. set_default_history_provider writes the file too, and unlike this it
+# has no expiry -- so removing this leaves settings.json a path the hook still
+# writes, on every device that has the QuestDB app.
 def migrate_gpsd_liner(sk_fd):
     """Splice the missing Liner into a gpsd connection seeded before the fix.
 
@@ -404,9 +520,9 @@ def migrate_gpsd_liner(sk_fd):
     change the connection's identity in the admin UI -- more than repairing the
     defect we shipped.
 
-    This is the only writer of settings.json here, and the reason that path needs
-    the same discipline as the secret files above: what makes it dangerous is
-    root writing into a directory uid 1000 owns, not the contents.
+    settings.json needs the same discipline as the secret files above, and for a
+    different reason: what makes it dangerous is root writing into a directory
+    uid 1000 owns, not the contents.
 
     ExecStartPre is where this belongs because the unit stops the container before
     it restarts, so Signal K -- the file's other writer -- is normally not running
@@ -431,27 +547,10 @@ def migrate_gpsd_liner(sk_fd):
     except FileNotFoundError:
         pass
 
-    try:
-        fd = open_regular(sk_fd, "settings.json")
-    except FileNotFoundError:
-        return  # a fresh install has none until the postinst seeds default-data
-
-    # UTF-8 explicitly: settings.json is UTF-8 by specification, and text mode
-    # otherwise decodes it in the process locale. Under a single-byte locale a
-    # vessel name comes back as two characters that json.dumps then re-escapes,
-    # so the rewrite would corrupt a value it was not asked to touch.
-    with os.fdopen(fd, encoding="utf-8") as f:  # owns fd from here
-        # Permission bits only. uid 1000 owns settings.json and chooses its mode,
-        # and S_IMODE keeps setuid and setgid as well -- root would reproduce them
-        # on a file it creates here and, for the backup, never hands over.
-        mode = stat.S_IMODE(os.fstat(f.fileno()).st_mode) & 0o777
-        original = f.read()
-
-    settings = json.loads(original)
-    if not isinstance(settings, dict):
-        raise ValueError(
-            "settings.json is a %s, not an object" % type(settings).__name__
-        )
+    read = read_settings(sk_fd)
+    if read is None:
+        return
+    settings, mode, original = read
 
     spliced = False
     for provider in settings.get("pipedProviders") or []:
@@ -470,18 +569,10 @@ def migrate_gpsd_liner(sk_fd):
     if not spliced:
         return
 
-    # Not settings.json.tmp: that is the name the server's own atomic write stages
-    # through, so a leftover there is a root-owned file in its way and its next
-    # save fails EACCES.
-    tmp = "settings.json.halos-tmp"
-    body = json.dumps(settings, indent=2) + "\n"
-    if not create_guarded(sk_fd, tmp, body, replace=True, mode=mode):
-        warn("cannot write %s; leaving the gpsd connection alone" % tmp)
+    if not write_settings(sk_fd, settings, mode):
+        warn("cannot stage the rewrite; leaving the gpsd connection alone")
         return
 
-    # renameat replaces the name and never follows it, so a symlink swapped in
-    # after the read above is overwritten rather than written through.
-    os.replace(tmp, "settings.json", src_dir_fd=sk_fd, dst_dir_fd=sk_fd)
     print("Added the missing providers/liner to the gpsd connection")
 
     # The record of the repair goes down after the repair, never before. Anything
@@ -566,6 +657,16 @@ if QUESTDB_INSTALLED:
         configure_questdb(sk_fd)
     except Exception as exc:
         warn("QuestDB plugin config not written: %s" % exc)
+
+# Unconditional, unlike the plugin config above: this runs to clear the key on
+# a device the app was removed from, which is a state only reachable with
+# QUESTDB_INSTALLED false. Separate from the config for the rest -- they fail
+# for different reasons, and the plugin still records when only the default is
+# missing.
+try:
+    set_default_history_provider(sk_fd, QUESTDB_INSTALLED)
+except Exception as exc:
+    warn("default history provider not updated: %s" % exc)
 
 os.close(sk_fd)
 os.close(root_fd)

--- a/tools/test-prestart.sh
+++ b/tools/test-prestart.sh
@@ -164,7 +164,7 @@ run_hook() {  # echoes exit status
         RUNTIME_ENV="${SANDBOX}/runtime.env" \
         HALOS_DOMAIN="test.local" \
         INFLUXDB_ENV="${SANDBOX}/influxdb.env" \
-        QUESTDB_ENV="${SANDBOX}/questdb.env" \
+        QUESTDB_COMPOSE="${SANDBOX}/questdb-compose.yml" \
         PYTHONPATH="${SANDBOX}/pylib" \
         ${TIMEOUT:+"${TIMEOUT}" -s KILL 20} \
         bash -c 'set -e; . "$1"' _ "${HOOK}" > "${SANDBOX}/out" 2>&1
@@ -175,8 +175,8 @@ influx_available() {  # $1 = token to publish
     printf 'INFLUXDB_ADMIN_TOKEN=%s\n' "$1" > "${SANDBOX}/influxdb.env"
 }
 
-questdb_available() {  # the app's env file is the only signal; it holds no secret
-    : > "${SANDBOX}/questdb.env"
+questdb_available() {  # the app's compose file is the signal; see the hook
+    : > "${SANDBOX}/questdb-compose.yml"
 }
 
 # Matches the whole call, not just the path. Asserting only that the path was
@@ -269,16 +269,19 @@ questdb_available
 check "questdb config is written when the app is installed" "$(run_hook)" "0"
 QDB_CFG="${SK}/plugin-config-data/signalk-questdb-history-provider.json"
 check "  at 0600" "$(mode "${QDB_CFG}")" "600"
-python3 - "${QDB_CFG}" <<'EOF' && ok "  external mode, loopback, promotion armed" ||
+python3 - "${QDB_CFG}" <<'EOF' && ok "  external mode, loopback, no promotion flag" ||
 import json, sys
 c = json.load(open(sys.argv[1]))
 cfg = c["configuration"]
 assert c["enabled"] is True, c
 assert cfg["managedContainer"] is False, cfg
 assert cfg["questdbHost"] == "127.0.0.1", cfg
-assert cfg["promoteToDefaultProvider"] is True, cfg
+# The plugin cannot promote itself: the route is admin-authenticated and it
+# calls its own server with no credentials, so arming this only buys a 401 in
+# the log on every boot. settings.json carries the default instead.
+assert "promoteToDefaultProvider" not in cfg, cfg
 EOF
-    bad "  external mode, loopback, promotion armed" "$(cat "${QDB_CFG}")"
+    bad "  external mode, loopback, no promotion flag" "$(cat "${QDB_CFG}")"
 teardown
 
 setup
@@ -291,8 +294,7 @@ teardown
 # Write once, never rewrite. InfluxDB's config is rewritten every boot because a
 # rotating token has to reach it; this one carries no secret, so rewriting would
 # only ever discard what the operator changed -- path filters, sampling rates,
-# retention -- on the next restart. It would also re-arm the one-off promotion,
-# taking back a default the operator had since moved elsewhere.
+# retention -- on the next restart.
 setup
 questdb_available
 run_hook > /dev/null
@@ -301,7 +303,7 @@ python3 - "${QDB_CFG}" <<'EOF'
 import json, sys
 c = json.load(open(sys.argv[1]))
 c["configuration"]["retentionDays"] = 30
-c["configuration"]["promoteToDefaultProvider"] = False
+c["configuration"]["questdbHost"] = "192.168.1.50"
 json.dump(c, open(sys.argv[1], "w"))
 EOF
 check "an edited questdb config survives the next boot" "$(run_hook)" "0"
@@ -309,9 +311,114 @@ python3 - "${QDB_CFG}" <<'EOF' && ok "  operator edits are intact" ||
 import json, sys
 cfg = json.load(open(sys.argv[1]))["configuration"]
 assert cfg["retentionDays"] == 30, cfg
-assert cfg["promoteToDefaultProvider"] is False, cfg
+assert cfg["questdbHost"] == "192.168.1.50", cfg
 EOF
     bad "  operator edits are intact" "$(cat "${QDB_CFG}")"
+teardown
+
+# The default history provider. Signal K serves history from whichever provider
+# registered first when settings name none, and signalk-to-influxdb2 is baked
+# into the same image -- so on a device with both apps it is plugin load order
+# that decides, and InfluxDB wins it. settings.json is the only place the server
+# takes this from; the plugin's own route for it is admin-authenticated.
+SETTINGS='{"interfaces":{"nmea-tcp":false},"vessel":{"uuid":"urn:mrn:signalk:uuid:test"}}'
+default_provider() {  # echoes the configured id, or the empty string
+    python3 -c 'import json,sys; print((json.load(open(sys.argv[1])).get("historyApi") or {}).get("defaultProvider",""))' "$1"
+}
+
+setup
+questdb_available
+printf '%s\n' "${SETTINGS}" > "${SK}/settings.json"
+chmod 644 "${SK}/settings.json"
+check "questdb becomes the default history provider" "$(run_hook)" "0"
+check "  named in settings.json" \
+    "$(default_provider "${SK}/settings.json")" "signalk-questdb-history-provider"
+check "  the file keeps its mode" "$(mode "${SK}/settings.json")" "644"
+python3 - "${SK}/settings.json" <<'EOF' && ok "  nothing else in the document changes" ||
+import json, sys
+s = json.load(open(sys.argv[1]))
+assert s["vessel"]["uuid"] == "urn:mrn:signalk:uuid:test", s
+assert s["interfaces"] == {"nmea-tcp": False}, s
+EOF
+    bad "  nothing else in the document changes" "$(cat "${SK}/settings.json")"
+teardown
+
+# The operator's choice outranks ours, and it is a plain key with no backup file
+# to record that we already ran -- so absence of the key is the only signal that
+# nobody has chosen. Rewriting it every boot would take the choice back.
+setup
+questdb_available
+printf '%s\n' '{"historyApi":{"defaultProvider":"signalk-to-influxdb2"}}' > "${SK}/settings.json"
+check "a chosen default history provider is left alone" "$(run_hook)" "0"
+check "  still InfluxDB" \
+    "$(default_provider "${SK}/settings.json")" "signalk-to-influxdb2"
+teardown
+
+# Presence, not truthiness. An empty value is how the server reads "no default,
+# use whichever registers first" -- a choice like any other, and one a truthiness
+# test would overwrite on every boot.
+setup
+questdb_available
+printf '%s\n' '{"historyApi":{"defaultProvider":""}}' > "${SK}/settings.json"
+check "an emptied default history provider is left alone" "$(run_hook)" "0"
+check "  still empty" "$(default_provider "${SK}/settings.json")" ""
+teardown
+
+# Nothing here knows what a non-object historyApi was meant to be, and replacing
+# it would discard whatever it held.
+setup
+questdb_available
+printf '%s\n' '{"historyApi":"nonsense"}' > "${SK}/settings.json"
+check "a malformed historyApi does not block the start" "$(run_hook)" "0"
+check "  and is left as it was" \
+    "$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["historyApi"])' "${SK}/settings.json")" \
+    "nonsense"
+teardown
+
+setup
+printf '%s\n' "${SETTINGS}" > "${SK}/settings.json"
+check "no default history provider without the questdb app" "$(run_hook)" "0"
+check "  settings name none" "$(default_provider "${SK}/settings.json")" ""
+teardown
+
+# Removing the app has to take the key with it. A configured provider that
+# never registers is not silent: the first history request after that raises a
+# warn notification at notifications.server.history.defaultProvider, and the
+# server clears it only when that provider registers again -- never, for an app
+# that is gone. So it is a standing alarm on the vessel, not a fallback.
+setup
+printf '%s\n' '{"historyApi":{"defaultProvider":"signalk-questdb-history-provider"},"vessel":{"uuid":"x"}}' \
+    > "${SK}/settings.json"
+check "removing the questdb app clears the default" "$(run_hook)" "0"
+check "  the key is gone" "$(default_provider "${SK}/settings.json")" ""
+python3 - "${SK}/settings.json" <<'EOF' && ok "  historyApi survives, and so does the rest" ||
+import json, sys
+s = json.load(open(sys.argv[1]))
+assert "defaultProvider" not in s["historyApi"], s
+assert s["vessel"]["uuid"] == "x", s
+EOF
+    bad "  historyApi survives, and so does the rest" "$(cat "${SK}/settings.json")"
+teardown
+
+# Exact match only. Whatever else the operator chose is theirs, and the app
+# being absent says nothing about whether they still want it.
+setup
+printf '%s\n' '{"historyApi":{"defaultProvider":"signalk-to-influxdb2"}}' > "${SK}/settings.json"
+check "removing questdb leaves another provider alone" "$(run_hook)" "0"
+check "  still InfluxDB" \
+    "$(default_provider "${SK}/settings.json")" "signalk-to-influxdb2"
+teardown
+
+# A fresh install has no settings.json until the postinst seeds default-data, and
+# the hook runs before that on the very first start. Writing a partial file here
+# would lose every default the seed carries, so it does nothing and the next boot
+# picks it up.
+setup
+questdb_available
+check "a missing settings.json is not created" "$(run_hook)" "0"
+[ ! -e "${SK}/settings.json" ] &&
+    ok "  settings.json is still absent" ||
+    bad "  settings.json is still absent" "$(cat "${SK}/settings.json")"
 teardown
 
 # signalk-halpi's postinst creates both paths as root before Signal K has ever


### PR DESCRIPTION
QuestDB shipped as the default history provider and was not one. On a device with both the QuestDB and InfluxDB apps installed — the configuration we ship — `/signalk/v2/api/history/_providers` reported `signalk-to-influxdb2` as `isDefault: true`. The QuestDB app recorded data that nothing read.

Two causes, both confirmed on halosdev.hal rather than inferred:

The plugin cannot claim the default itself. `POST /signalk/v2/api/history/_providers/_default/:id` is behind `adminAuthenticationMiddleware`, and a plugin reaches that route as an ordinary loopback client carrying no credentials. It got 401 on every boot and logged a retry that could never succeed. Security is enabled on every HaLOS device, so there is no configuration where the old mechanism worked.

With no default configured, the server serves history from whichever provider registered first — plugin load order, and `signalk-to-influxdb2` is baked into the same image.

## Approach

`settings.json`'s `historyApi.defaultProvider` is the only place the server persists this, so the prestart writes it: once, when the QuestDB app is installed and the key is absent. An operator who moves the default to InfluxDB keeps it. Removing the QuestDB app needs no cleanup — an unregistered provider falls back to the first one that did, silently, which I verified by pointing the key at an id that does not exist.

`settings.json` now has two writers, so the read and the atomic replace are factored into `read_settings` and `write_settings` instead of copied. The read carries three ways to corrupt a value it was not asked to touch — the mode uid 1000 chose, UTF-8 versus the process locale, and a document that is not an object — and a second copy only has to drift on one of them. The gpsd migration's `REMOVE AFTER` note now says which parts survive its removal.

The plugin-side promotion flag is a separate follow-up in the fork; this PR stops arming it.

## Verification

On halosdev.hal, with both apps installed and signalk-server 2.31.1:

- before: `{"signalk-to-influxdb2":{"isDefault":true},"signalk-questdb-history-provider":{"isDefault":false}}`
- after: `{"signalk-to-influxdb2":{"isDefault":false},"signalk-questdb-history-provider":{"isDefault":true}}`
- an operator choice of `signalk-to-influxdb2` survives a restart, and `settings.json` keeps `pi:pi` and mode 644

This needs signalk-server 2.31.0 or newer — persistence landed there, and on 2.30.0 the key is inert in both directions. The pinned image is 2.31.1.

`tools/test-prestart.sh` gains five scenarios covering the write, the operator's choice, the app being absent, and a missing `settings.json` on a first boot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - QuestDB is now automatically selected as the default history provider when available and no provider is configured.
  - Existing provider choices and unrelated settings are preserved.
  - Settings updates retain file permissions, UTF-8 content, and document structure.
  - Startup continues safely if QuestDB configuration cannot be applied.

- **Documentation**
  - Expanded guidance for settings updates and QuestDB configuration, including limitations, fallback behavior, persistence, cleanup, and version requirements.

- **Chores**
  - Updated the Signal K Server package revision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->