### PR TITLE
Provision a QuestDB datasource in Grafana

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,6 +224,36 @@ volumes under a temp directory, and never touches `/etc` or a device. Run it
 after changing `apps/influxdb/prestart.sh`; it is not part of CI because it
 pulls and boots the InfluxDB image.
 
+### Grafana Prestart Hook
+
+Grafana `recommends` both datastores rather than depending on them, so
+`apps/grafana/prestart.sh` decides at every start which datasources exist:
+`assets/influxdb-datasource.yaml` and `assets/questdb-datasource.yaml` are
+copied into the provisioning directory when their app is installed and taken out
+when it is not. It runs in CI, via `tests/test_grafana_prestart.py`:
+
+```bash
+./tools/test-grafana-prestart.sh
+```
+
+**"Installed" is the app's compose file, never its env file.** `apt remove`
+leaves the package in `deinstall ok config-files`, where
+`/etc/container-apps/<app>/env` and the systemd unit both survive and only
+`apt purge` takes them; `/var/lib/container-apps/<app>/docker-compose.yml` is
+payload and goes on either. InfluxDB's env file is still read, because the token
+in it is what the datasource refers to as `$__env{INFLUXDB_TOKEN}` — so the two
+files are checked for different things and both are needed.
+
+QuestDB needs no such value. Its open-source build has no user management, so
+the pg wire credentials are fixed upstream defaults, identical on every device,
+and the asset is complete on its own.
+
+**Taking the file out does not delete the datasource.** Grafana removes a
+provisioned datasource only on an explicit `deleteDatasources` stanza, so after
+an uninstall the datasource stays in Grafana's own database, visible and
+failing, until an operator deletes it. The hook stops re-provisioning it and
+nothing more.
+
 ### Signal K Prestart Hook
 
 `apps/signalk-server/prestart.sh` has a bash harness that stubs chown, so it

--- a/apps/grafana/assets/questdb-datasource.yaml
+++ b/apps/grafana/assets/questdb-datasource.yaml
@@ -1,0 +1,32 @@
+apiVersion: 1
+
+# QuestDB over its PostgreSQL wire protocol, which Grafana's core postgres
+# datasource speaks -- no plugin to install, so nothing here needs the network
+# at container start.
+#
+# The QuestDB history provider plugin in Signal K writes three tables, all with
+# `ts` as the designated timestamp and `context`/`source` symbols: `signalk`
+# (numeric values), `signalk_str` (text) and `signalk_position` (lat/lon).
+#
+# These credentials are QuestDB's open-source defaults, identical on every
+# device. Its community build has no user management, so there is nothing
+# per-device to provision and no secret to keep out of the package -- the whole
+# gate is that the port is published on loopback and carries no Traefik router.
+# apps/questdb/docker-compose.yml states what that does and does not bound.
+#
+# postgresVersion is what QuestDB answers with over the wire: `select version()`
+# returns "PostgreSQL 12.3, compiled by Visual C++ build 1914, 64-bit, QuestDB".
+datasources:
+  - name: QuestDB
+    type: postgres
+    access: proxy
+    url: questdb:8812
+    user: admin
+    database: qdb
+    jsonData:
+      sslmode: disable
+      postgresVersion: 1200
+      timescaledb: false
+    secureJsonData:
+      password: quest
+    editable: true

--- a/apps/grafana/metadata.yaml
+++ b/apps/grafana/metadata.yaml
@@ -1,12 +1,13 @@
 name: Grafana
 app_id: grafana
-version: 13.1.3-1
+version: 13.1.3-2
 upstream_version: 13.1.3
 description: Data visualization and monitoring platform
 long_description: |
   Grafana is an open-source platform for monitoring and observability. Create
-  beautiful dashboards to visualize marine data from InfluxDB, Signal K, and
-  other data sources.
+  beautiful dashboards to visualize marine data recorded by QuestDB and
+  InfluxDB. A datasource for each is provisioned automatically when that app
+  is installed, so a fresh dashboard has something to query.
 
   Features:
   - Rich visualization options (graphs, gauges, maps)
@@ -31,6 +32,7 @@ depends:
   - docker.io (>= 20.10) | docker-ce (>= 20.10)
 recommends:
   - marine-influxdb-container
+  - marine-questdb-container
 web_ui:
   enabled: true
   path: /

--- a/apps/grafana/prestart.sh
+++ b/apps/grafana/prestart.sh
@@ -18,25 +18,49 @@ fi
 mkdir -p "${CONTAINER_DATA_ROOT}/data"
 chown -R 472:472 "${CONTAINER_DATA_ROOT}/data"
 
-# --- InfluxDB datasource provisioning ---
-# Provisioning is conditional on InfluxDB (Grafana only recommends it), so the
-# datasource is copied in when InfluxDB + its token are present and removed
-# otherwise — it is not unconditional static seed. Grafana expands
-# $__env{INFLUXDB_TOKEN} (supplied via runtime.env) at startup.
-INFLUXDB_ENV="/etc/container-apps/marine-influxdb-container/env"
+# --- datasource provisioning ---
+# Grafana only recommends the two datastores, so each datasource is copied in
+# when its app is there and taken out when it is not — this is not an
+# unconditional static seed.
+#
+# Removing the file stops Grafana re-provisioning the datasource; it does not
+# delete the row Grafana already wrote into its own database. Grafana only
+# deletes on an explicit `deleteDatasources` stanza. So after uninstalling an
+# app its datasource stays visible and failing until an operator deletes it.
+ASSETS_DIR="${ASSETS_DIR:-/var/lib/container-apps/marine-grafana-container/assets}"
 PROVISIONING_DIR="${CONTAINER_DATA_ROOT}/provisioning/datasources"
-DATASOURCE_SRC="/var/lib/container-apps/marine-grafana-container/assets/influxdb-datasource.yaml"
-DATASOURCE_DST="${PROVISIONING_DIR}/influxdb.yaml"
 mkdir -p "${PROVISIONING_DIR}"
-if [ -f "${INFLUXDB_ENV}" ]; then
+
+# The gate is the app's compose file, not its env file under /etc. `apt remove`
+# leaves a package in `deinstall ok config-files`, where the env file and the
+# systemd unit both survive and only `apt purge` takes them; the compose file is
+# payload and goes on either. Verified on a device.
+INFLUXDB_COMPOSE="${INFLUXDB_COMPOSE:-/var/lib/container-apps/marine-influxdb-container/docker-compose.yml}"
+QUESTDB_COMPOSE="${QUESTDB_COMPOSE:-/var/lib/container-apps/marine-questdb-container/docker-compose.yml}"
+
+# InfluxDB authenticates with a per-device token, which the asset refers to as
+# $__env{INFLUXDB_TOKEN} and Grafana expands at startup. The token comes from
+# InfluxDB's own env file, so both files have to be there.
+INFLUXDB_ENV="${INFLUXDB_ENV:-/etc/container-apps/marine-influxdb-container/env}"
+INFLUXDB_DST="${PROVISIONING_DIR}/influxdb.yaml"
+INFLUXDB_ADMIN_TOKEN=""
+if [ -f "${INFLUXDB_COMPOSE}" ] && [ -f "${INFLUXDB_ENV}" ]; then
     INFLUXDB_ADMIN_TOKEN=$(grep '^INFLUXDB_ADMIN_TOKEN=' "${INFLUXDB_ENV}" | cut -d= -f2-)
-    if [ -n "${INFLUXDB_ADMIN_TOKEN}" ] && [ -f "${DATASOURCE_SRC}" ]; then
-        cp "${DATASOURCE_SRC}" "${DATASOURCE_DST}"
-        echo "INFLUXDB_TOKEN=${INFLUXDB_ADMIN_TOKEN}" >> "$RUNTIME_ENV"
-    else
-        rm -f "${DATASOURCE_DST}"
-    fi
-else
-    rm -f "${DATASOURCE_DST}"
 fi
+if [ -n "${INFLUXDB_ADMIN_TOKEN}" ] && [ -f "${ASSETS_DIR}/influxdb-datasource.yaml" ]; then
+    cp "${ASSETS_DIR}/influxdb-datasource.yaml" "${INFLUXDB_DST}"
+    echo "INFLUXDB_TOKEN=${INFLUXDB_ADMIN_TOKEN}" >> "$RUNTIME_ENV"
+else
+    rm -f "${INFLUXDB_DST}"
+fi
+
+# QuestDB's credentials are its open-source build's fixed defaults, so the asset
+# is complete on its own and nothing about it goes into runtime.env.
+QUESTDB_DST="${PROVISIONING_DIR}/questdb.yaml"
+if [ -f "${QUESTDB_COMPOSE}" ] && [ -f "${ASSETS_DIR}/questdb-datasource.yaml" ]; then
+    cp "${ASSETS_DIR}/questdb-datasource.yaml" "${QUESTDB_DST}"
+else
+    rm -f "${QUESTDB_DST}"
+fi
+
 chown -R 472:472 "${PROVISIONING_DIR}"

--- a/tests/test_grafana_prestart.py
+++ b/tests/test_grafana_prestart.py
@@ -1,0 +1,116 @@
+"""Tests for the Grafana app's datasource provisioning.
+
+Grafana only recommends the two datastores, so which datasources exist is
+decided at every start by what is installed. The failure mode when that goes
+wrong is quiet: Grafana starts, the dashboard list is intact, and only a panel
+query says anything -- so the checks that matter are about which file the hook
+looks at and what it copies, neither of which any device symptom points to.
+"""
+
+import subprocess
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).parent.parent
+APP_DIR = REPO_ROOT / "apps" / "grafana"
+ASSETS_DIR = APP_DIR / "assets"
+
+
+def _yaml(path: Path) -> dict:
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def hook_code() -> str:
+    """The hook's text, minus comment lines.
+
+    The guards below are substring checks, and this repo's house style puts the
+    reasoning directly above the code it justifies -- so matching the whole file
+    would fire on prose and discourage writing it.
+    """
+    lines = (APP_DIR / "prestart.sh").read_text().splitlines()
+    return "\n".join(line for line in lines if not line.lstrip().startswith("#"))
+
+
+def test_prestart_is_executable():
+    assert APP_DIR.joinpath("prestart.sh").stat().st_mode & 0o111
+
+
+def test_prestart_hook_behaves():
+    """Run the hook against sandboxed install states with chown stubbed.
+
+    Which datasources exist afterwards is a property of the filesystem, which no
+    assertion on the script's text reaches.
+    """
+    harness = REPO_ROOT / "tools" / "test-grafana-prestart.sh"
+
+    result = subprocess.run(
+        ["bash", str(harness)], capture_output=True, text=True, timeout=120
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_installed_means_the_compose_file():
+    """`apt remove` is not `apt purge`, and only one of them takes the env file.
+
+    A removed package lands in `deinstall ok config-files`, where
+    /etc/container-apps/<app>/env and the systemd unit both survive; the compose
+    file is payload and goes on either. Gating on the env file made "the app is
+    gone" false for the ordinary uninstall, so Grafana kept a datasource
+    pointing at a container that can no longer start.
+    """
+    code = hook_code()
+
+    for app in ("influxdb", "questdb"):
+        gate = f'[ -f "${{{app.upper()}_COMPOSE}}" ]'
+        assert gate in code, f"{app} is not gated on its compose file"
+
+    # The InfluxDB env file is still read -- it holds the token -- so the guard
+    # above is not enough on its own: it would pass with an `||` in place of the
+    # `&&` that makes the compose file necessary rather than sufficient.
+    assert '[ -f "${INFLUXDB_COMPOSE}" ] && [ -f "${INFLUXDB_ENV}" ]' in code
+
+
+def test_questdb_datasource_reaches_the_port_the_app_publishes():
+    """The datasource hard-codes host and port; the app decides both.
+
+    Grafana reaches QuestDB over halos-proxy-network, so the container port is
+    what it connects to and the loopback publication in the compose file is not
+    involved. A repin that moves the PostgreSQL wire port would leave this
+    datasource pointing at a closed port, and nothing else in either repo
+    compares the two.
+    """
+    datasource = _yaml(ASSETS_DIR / "questdb-datasource.yaml")["datasources"][0]
+    assert datasource["type"] == "postgres"
+
+    host, _, port = datasource["url"].partition(":")
+
+    compose = _yaml(REPO_ROOT / "apps" / "questdb" / "docker-compose.yml")
+    service_name, service = next(iter(compose["services"].items()))
+    assert host == service.get("container_name", service_name)
+
+    container_ports = {mapping.rsplit(":", 1)[-1] for mapping in service["ports"]}
+    assert port in container_ports, (
+        f"the datasource dials {port}, which apps/questdb publishes no service on"
+    )
+
+
+def test_grafana_recommends_every_datastore_it_provisions():
+    """Recommends is what puts the app in front of someone installing Grafana.
+
+    A datasource whose app is not recommended is provisioned for a database that
+    nothing suggested installing, so the default experience is a dashboard with
+    nothing to query.
+    """
+    recommends = set(_yaml(APP_DIR / "metadata.yaml")["recommends"])
+
+    provisioned = {
+        _yaml(asset)["datasources"][0]["name"].lower()
+        for asset in ASSETS_DIR.glob("*-datasource.yaml")
+    }
+    assert provisioned, "no datasource assets found -- the check would pass vacuously"
+
+    for name in provisioned:
+        assert f"marine-{name}-container" in recommends

--- a/tools/test-grafana-prestart.sh
+++ b/tools/test-grafana-prestart.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# Exercise the datasource provisioning in apps/grafana/prestart.sh.
+#
+# The hook decides which Grafana datasources exist from what is installed on the
+# host, and that decision is a set of files on disk after it runs -- not
+# anything an assertion on the script's text reaches. So each scenario builds an
+# install state under a temp directory, runs the hook the way ExecStartPre runs
+# it (sourced under `set -e`), and then looks at the provisioning directory.
+#
+# The install states include the one `apt remove` leaves behind, where the
+# compose file is gone and the env file under /etc is not. That asymmetry is the
+# whole reason the gate is the compose file, and it is invisible from the hook.
+#
+# chown is stubbed. The run is unprivileged, so no uid here could ever be the
+# container's; what the hook asked for is the ceiling this harness reaches.
+#
+# Needs no Docker, no network and no root.
+#
+# Usage: tools/test-grafana-prestart.sh
+set -u
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HOOK="${REPO_ROOT}/apps/grafana/prestart.sh"
+PACKAGED_ASSETS="${REPO_ROOT}/apps/grafana/assets"
+WORKSPACE="$(mktemp -d)"
+SHIM_DIR="${WORKSPACE}/shim"
+CHOWN_LOG="${WORKSPACE}/chown-calls.log"
+trap 'rm -rf "${WORKSPACE}"' EXIT
+
+pass=0
+fail=0
+ok()    { printf '  ok   %s\n' "$1"; pass=$((pass + 1)); }
+bad()   { printf '  FAIL %s\n' "$1"; printf '       %s\n' "$2"; fail=$((fail + 1)); }
+check() { [ "$2" = "$3" ] && ok "$1" || bad "$1" "expected '$3', got '$2'"; }
+scenario() { printf '\n%s\n' "$1"; }
+
+mkdir -p "${SHIM_DIR}"
+cat > "${SHIM_DIR}/chown" <<'SHIM'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${CHOWN_CALL_LOG}"
+SHIM
+chmod +x "${SHIM_DIR}/chown"
+
+sandbox() { # sandbox <name>
+    ROOT="${WORKSPACE}/$1"
+    rm -rf "${ROOT:?}"
+    DATA="${ROOT}/data"
+    ETC="${ROOT}/etc"
+    LIB="${ROOT}/lib"
+    ASSETS="${PACKAGED_ASSETS}"
+    RUNTIME="${ROOT}/runtime.env"
+    PROVISIONED="${DATA}/provisioning/datasources"
+    mkdir -p "${DATA}" "${ETC}" "${LIB}"
+    : > "${RUNTIME}"
+}
+
+# `apt install`: payload under /var/lib, conffiles under /etc.
+install_influxdb() { # install_influxdb [token]
+    mkdir -p "${LIB}/marine-influxdb-container" "${ETC}/marine-influxdb-container"
+    printf 'services: {}\n' > "${LIB}/marine-influxdb-container/docker-compose.yml"
+    printf 'INFLUXDB_ADMIN_TOKEN=%s\n' "${1-influx-admin-token}" \
+        > "${ETC}/marine-influxdb-container/env"
+}
+
+install_questdb() {
+    mkdir -p "${LIB}/marine-questdb-container" "${ETC}/marine-questdb-container"
+    printf 'services: {}\n' > "${LIB}/marine-questdb-container/docker-compose.yml"
+    printf 'QUESTDB_MEMORY_LIMIT=768m\n' > "${ETC}/marine-questdb-container/env"
+}
+
+# `apt remove`, not purge: the package lands in `deinstall ok config-files`, so
+# the payload goes and everything under /etc stays.
+remove_app() { rm -f "${LIB}/marine-$1-container/docker-compose.yml"; }
+
+run_hook() {
+    : > "${CHOWN_LOG}"
+    HOOK_OUTPUT=$(env \
+        CONTAINER_DATA_ROOT="${DATA}" \
+        RUNTIME_ENV="${RUNTIME}" \
+        HALOS_DOMAIN="halos.test" \
+        ASSETS_DIR="${ASSETS}" \
+        INFLUXDB_COMPOSE="${LIB}/marine-influxdb-container/docker-compose.yml" \
+        INFLUXDB_ENV="${ETC}/marine-influxdb-container/env" \
+        QUESTDB_COMPOSE="${LIB}/marine-questdb-container/docker-compose.yml" \
+        PATH="${SHIM_DIR}:${PATH}" \
+        CHOWN_CALL_LOG="${CHOWN_LOG}" \
+        bash -c 'set -e; . "$1"' _ "${HOOK}" 2>&1)
+    HOOK_STATUS=$?
+}
+
+present()   { [ -f "${PROVISIONED}/$1" ] && echo yes || echo no; }
+verbatim()  { cmp -s "${PROVISIONED}/$1" "${ASSETS}/$2" && echo yes || echo no; }
+token_lines() { grep -c '^INFLUXDB_TOKEN=' "${RUNTIME}"; }
+
+echo "Testing ${HOOK}"
+
+scenario "1. Both datastores installed"
+sandbox both
+install_influxdb
+install_questdb
+run_hook
+check "hook exits 0" "${HOOK_STATUS}" "0"
+check "InfluxDB datasource provisioned" "$(present influxdb.yaml)" "yes"
+check "QuestDB datasource provisioned" "$(present questdb.yaml)" "yes"
+check "QuestDB datasource is the packaged asset" "$(verbatim questdb.yaml questdb-datasource.yaml)" "yes"
+check "the InfluxDB token reaches runtime.env" "$(token_lines)" "1"
+check "the provisioning directory is handed to the container's uid" \
+    "$(grep -c -- "-R 472:472 ${PROVISIONED}" "${CHOWN_LOG}")" "1"
+
+scenario "2. QuestDB only"
+sandbox questdb_only
+install_questdb
+run_hook
+check "hook exits 0" "${HOOK_STATUS}" "0"
+check "QuestDB datasource provisioned" "$(present questdb.yaml)" "yes"
+check "no InfluxDB datasource" "$(present influxdb.yaml)" "no"
+check "nothing about a token in runtime.env" "$(token_lines)" "0"
+
+scenario "3. InfluxDB only"
+sandbox influx_only
+install_influxdb
+run_hook
+check "hook exits 0" "${HOOK_STATUS}" "0"
+check "InfluxDB datasource provisioned" "$(present influxdb.yaml)" "yes"
+check "no QuestDB datasource" "$(present questdb.yaml)" "no"
+
+scenario "4. Neither installed"
+sandbox neither
+run_hook
+check "hook exits 0" "${HOOK_STATUS}" "0"
+check "no InfluxDB datasource" "$(present influxdb.yaml)" "no"
+check "no QuestDB datasource" "$(present questdb.yaml)" "no"
+check "nothing about a token in runtime.env" "$(token_lines)" "0"
+
+# The regression this whole harness exists for. Gating on the env file made
+# "the app is gone" false for the ordinary uninstall, because that file
+# survives it -- so the datasource stayed, pointing at a container that can no
+# longer start.
+scenario "5. apt remove takes the datasource with it"
+sandbox removal
+install_influxdb
+install_questdb
+run_hook
+check "both provisioned to start with" \
+    "$(present influxdb.yaml)$(present questdb.yaml)" "yesyes"
+remove_app questdb
+run_hook
+check "hook exits 0" "${HOOK_STATUS}" "0"
+check "QuestDB env file survived the remove" \
+    "$([ -f "${ETC}/marine-questdb-container/env" ] && echo yes || echo no)" "yes"
+check "QuestDB datasource removed anyway" "$(present questdb.yaml)" "no"
+check "InfluxDB datasource untouched" "$(present influxdb.yaml)" "yes"
+remove_app influxdb
+: > "${RUNTIME}"
+run_hook
+check "hook exits 0" "${HOOK_STATUS}" "0"
+check "InfluxDB env file survived the remove" \
+    "$([ -f "${ETC}/marine-influxdb-container/env" ] && echo yes || echo no)" "yes"
+check "InfluxDB datasource removed anyway" "$(present influxdb.yaml)" "no"
+check "no token written for a removed InfluxDB" "$(token_lines)" "0"
+
+scenario "6. An installed InfluxDB whose env file carries no token"
+sandbox empty_token
+install_influxdb ""
+install_questdb
+run_hook
+check "hook exits 0" "${HOOK_STATUS}" "0"
+check "no InfluxDB datasource" "$(present influxdb.yaml)" "no"
+check "no empty token in runtime.env" "$(token_lines)" "0"
+check "QuestDB is unaffected" "$(present questdb.yaml)" "yes"
+
+# The assets are package payload. A datasource file naming $__env{} for a value
+# nothing supplies, or a copy of a file that was dropped from the .deb, both
+# read as "provisioned" to everything downstream.
+scenario "7. Assets missing from the package"
+sandbox no_assets
+install_influxdb
+install_questdb
+ASSETS="${ROOT}/empty-assets"
+mkdir -p "${ASSETS}"
+run_hook
+check "hook exits 0" "${HOOK_STATUS}" "0"
+check "no InfluxDB datasource" "$(present influxdb.yaml)" "no"
+check "no QuestDB datasource" "$(present questdb.yaml)" "no"
+check "no token for a datasource that was never written" "$(token_lines)" "0"
+
+printf '\nPASS=%s FAIL=%s\n' "${pass}" "${fail}"
+[ "${fail}" -eq 0 ]


### PR DESCRIPTION
Phase 4 of [issue 236](https://github.com/halos-org/halos-marine-containers/issues/236). QuestDB is where Signal K's history goes since phase 3, and Grafana had no way to read it.

## Approach

A datasource asset over QuestDB's PostgreSQL wire protocol, which Grafana's core postgres datasource speaks — so nothing has to be installed at container start, and no plugin has to be kept current. `apps/grafana/prestart.sh` copies it into the provisioning directory when the QuestDB app is installed and takes it out when it is not, the same shape as the InfluxDB block beside it, and `marine-questdb-container` joins Grafana's `recommends`.

The credentials are QuestDB's open-source defaults, identical on every device: its community build has no user management, so there is nothing per-device to provision and nothing for `runtime.env` to carry. `postgresVersion: 1200` is what QuestDB answers `select version()` with.

## The InfluxDB gate changes too

The InfluxDB block asked `/etc/container-apps/marine-influxdb-container/env` whether the app was installed. `apt remove` leaves a package in `deinstall ok config-files`, where that file and the systemd unit both survive and only `apt purge` takes them — so the removal branch was dead for the ordinary uninstall, and Grafana kept a datasource pointing at a container that can no longer start. The compose file is payload and goes on either, so both blocks gate on that now. InfluxDB's env file is still read for the token the asset refers to as `$__env{INFLUXDB_TOKEN}`; the two files answer different questions.

## What removal does and does not do

Removing a provisioning file stops Grafana re-provisioning the datasource. It does not delete the row Grafana already wrote — that needs an explicit `deleteDatasources` stanza. Confirmed on the device: after a restart with the file gone, `/api/datasources` still lists it. So an uninstalled app leaves a visible, failing datasource until an operator deletes it, and the comments say that rather than implying cleanup.

## Verification

On `halosdev.hal`, with the built `.deb` installed:

- both datasources provisioned, owned by uid 472
- `/api/datasources/uid/<questdb>/health` → `{"message":"Database Connection OK","status":"OK"}`
- a query through Grafana's datasource proxy — `SELECT ts, path, value FROM signalk ORDER BY ts DESC LIMIT 3` — returns live rows (`electrical.halpi.pcbTemperature` and friends)
- with QuestDB's compose file moved aside and Grafana restarted, `questdb.yaml` is gone and the env file is still there; moving it back brings the datasource back

Locally, `tools/test-grafana-prestart.sh` runs 34 assertions across seven install states with chown stubbed, no Docker and no network, and runs in CI through `tests/test_grafana_prestart.py`. Both gates were mutated to the env-file form to confirm the harness fails on exactly the assertion naming the defect.

Phase 5's remaining item after this is the docs.halos.fi page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W9sx1961rqYEgLa6f26KbR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Grafana datasource provisioning for InfluxDB and QuestDB.
  * Added QuestDB support using PostgreSQL wire protocol and configurable service details.
  * Grafana now recommends QuestDB alongside InfluxDB for marine data visualization.

* **Documentation**
  * Documented datasource provisioning, credential handling, installation detection, and removal behavior.

* **Tests**
  * Added comprehensive validation for datasource setup, configuration, cleanup, and missing prerequisites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->