### PR TITLE
Stop seeding the QuestDB plugin config with a setting the plugin dropped

### DIFF
--- a/apps/signalk-server/metadata.yaml
+++ b/apps/signalk-server/metadata.yaml
@@ -1,6 +1,6 @@
 name: Signal K Server
 app_id: signalk-server
-version: 2.31.1-3
+version: 2.31.1-4
 upstream_version: 2.31.1
 description: Signal K server for marine data processing and routing
 long_description: |

--- a/apps/signalk-server/prestart.sh
+++ b/apps/signalk-server/prestart.sh
@@ -348,7 +348,6 @@ def configure_questdb(sk_fd):
         if create_guarded(cfg_fd, name, json.dumps({
             "enabled": True,
             "configuration": {
-                "managedContainer": False,
                 "questdbHost": "127.0.0.1",
                 "questdbHttpPort": 9000,
                 "questdbIlpPort": 9009,

--- a/tools/test-prestart.sh
+++ b/tools/test-prestart.sh
@@ -269,19 +269,21 @@ questdb_available
 check "questdb config is written when the app is installed" "$(run_hook)" "0"
 QDB_CFG="${SK}/plugin-config-data/signalk-questdb-history-provider.json"
 check "  at 0600" "$(mode "${QDB_CFG}")" "600"
-python3 - "${QDB_CFG}" <<'EOF' && ok "  external mode, loopback, no promotion flag" ||
+python3 - "${QDB_CFG}" <<'EOF' && ok "  loopback, no managed container, no promotion flag" ||
 import json, sys
 c = json.load(open(sys.argv[1]))
 cfg = c["configuration"]
 assert c["enabled"] is True, c
-assert cfg["managedContainer"] is False, cfg
 assert cfg["questdbHost"] == "127.0.0.1", cfg
+# The plugin dropped this setting in 2.0.0 and its schema no longer defines
+# it, so writing it would seed every new device with a dead key.
+assert "managedContainer" not in cfg, cfg
 # The plugin cannot promote itself: the route is admin-authenticated and it
 # calls its own server with no credentials, so arming this only buys a 401 in
 # the log on every boot. settings.json carries the default instead.
 assert "promoteToDefaultProvider" not in cfg, cfg
 EOF
-    bad "  external mode, loopback, no promotion flag" "$(cat "${QDB_CFG}")"
+    bad "  loopback, no managed container, no promotion flag" "$(cat "${QDB_CFG}")"
 teardown
 
 setup


### PR DESCRIPTION
`configure_questdb` wrote `managedContainer: false` into every new device's plugin config. signalk-questdb-history-provider removed that setting in 2.0.0, so the key names nothing in the plugin's schema.

The write is once-only, so devices already configured keep the stale key. It is inert there, and rewriting an operator-editable config to remove it would cost more than it saves.

The test now asserts the key is absent rather than false, so re-adding it fails.

Verified against `main`: `tools/test-prestart.sh` fails the same 14 scenarios before and after this change (macOS-only; CI gates on Linux), and every QuestDB scenario passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved QuestDB history-provider configuration during startup.
  - Removed obsolete configuration settings that could interfere with provider setup.
  - Updated validation to confirm the provider is enabled and uses the local connection.

- **Chores**
  - Updated the Signal K Server package version to 2.31.1-4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->