### PR TITLE
Repin the Signal K image to v2.31.1-halos.3

### DIFF
--- a/apps/signalk-server/docker-compose.yml
+++ b/apps/signalk-server/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     # halos-org/signalk-server-docker. Exact tag, never a floating one: the tag
     # names an artifact that passed that repo's verification, and nothing in the
     # curated set is version-pinned, so a re-resolved rebuild is a different image.
-    image: ghcr.io/halos-org/signalk-server-docker:v2.31.1-halos.1
+    image: ghcr.io/halos-org/signalk-server-docker:v2.31.1-halos.3
     container_name: signalk-server
     init: true
     restart: unless-stopped

--- a/apps/signalk-server/metadata.yaml
+++ b/apps/signalk-server/metadata.yaml
@@ -1,6 +1,6 @@
 name: Signal K Server
 app_id: signalk-server
-version: 2.31.1-4
+version: 2.31.1-5
 upstream_version: 2.31.1
 description: Signal K server for marine data processing and routing
 long_description: |


### PR DESCRIPTION
`v2.31.1-halos.3` is the first image whose baked `signalk-questdb-history-provider` is 2.0.0. `-halos.1` (currently pinned) and `-halos.2` are byte-identical to each other and carry 1.0.0, resolved when the build cache was first populated; halos-org/signalk-server-docker#35 fixed the cause.

Repin plus the app version bump. No other change.

Devices take the new image at the next upgrade of `marine-signalk-server-container`. The plugin config the prestart wrote still names `managedContainer`, a setting 2.0.0 dropped, on devices configured before #247 — inert, and the config is write-once so it stays until an operator edits it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Signal K server image to the latest maintenance release.
  * Updated the package version to reflect the new server image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->